### PR TITLE
IPC methods for subscribing and selecting calendars

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,7 +8,7 @@ use p2panda_store::MemoryStore;
 use serde::ser::SerializeStruct;
 use serde::Serialize;
 use tauri::ipc::Channel;
-use tauri::{Builder, Manager, State};
+use tauri::{AppHandle, Builder, Manager, State};
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot, Mutex};
 
@@ -18,6 +18,7 @@ struct AppContext {
     node: Node<NetworkTopic>,
     store: MemoryStore<LogId, Extensions>,
     private_key: PrivateKey,
+    selected_calendar: Option<CalendarId>,
     #[allow(dead_code)]
     topic_map: TopicMap,
     channel_oneshot_tx: Option<oneshot::Sender<Channel<ChannelEvent>>>,
@@ -171,11 +172,13 @@ pub fn run() {
                     node,
                     store,
                     private_key,
+                    selected_calendar: None,
                     topic_map: topic_map.clone(),
                     channel_oneshot_tx: Some(channel_oneshot_tx),
                 }));
 
                 if let Err(err) = forward_to_app_layer(
+                    app_handle,
                     stream_rx,
                     topic_map,
                     invite_codes_rx,
@@ -205,6 +208,7 @@ pub fn run() {
 
 /// Task for receiving data from network and forwarding them up to the app layer.
 async fn forward_to_app_layer(
+    app: AppHandle,
     mut stream_rx: mpsc::Receiver<StreamEvent>,
     topic_map: TopicMap,
     mut invite_codes_rx: mpsc::Receiver<FromNetwork>,
@@ -240,8 +244,16 @@ async fn forward_to_app_layer(
                     let StreamEvent { meta, .. } = &event;
                     topic_map.add_author(meta.public_key, meta.calendar_id).await;
 
-                    // Send event further up to application layer.
-                    channel.send(ChannelEvent::Stream(event)).unwrap();
+                    // Check if the event is associated with the currently selected calendar. We
+                    // only forward it up to the application if it is.
+                    let state = app.state::<Mutex<AppContext>>();
+                    let state = state.lock().await;
+                    if let Some(selected_calendar) = state.selected_calendar {
+                        if selected_calendar != meta.calendar_id {
+                            return;
+                        };
+                        channel.send(ChannelEvent::Stream(event)).unwrap();
+                    }
                 },
                 Some(event) = invite_codes_rx.recv() => {
                     let json = match event {

--- a/src-tauri/src/topic.rs
+++ b/src-tauri/src/topic.rs
@@ -24,7 +24,7 @@ pub struct Calendar {
 #[serde(tag = "t", content = "c", rename_all = "snake_case")]
 pub enum NetworkTopic {
     InviteCodes,
-    Calendar { calendar_id: Hash },
+    Calendar { calendar_id: CalendarId },
 }
 
 impl TopicQuery for NetworkTopic {}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -97,24 +97,27 @@ export async function createCalendar(payload: any): Promise<string> {
   // happen on the frontend with follow-up IPC calls. This can be refactored when
   // https://github.com/toolkitties/toolkitty/issues/69 is implemented.
   let hash: string = await invoke("create_calendar", { payload });
-  addCalendar({ id: hash, name: null });
 
   // Register this operation in the promise map.
   let ready = addPromise(hash);
 
-  // Wait for the promise to be resolved.
+  addCalendar({ id: hash, name: "" });
+
+  // Wait for the operation promise to be resolved.
   await ready;
 
   return hash;
 }
 
-export async function subscribeToCalendar(calendarId: string): Promise<void> {
+export async function subscribeToCalendar(
+  calendarId: string
+): Promise<unknown> {
   await invoke("subscribe_to_calendar", { calendarId });
-  addCalendar({ id: calendarId, name: null });
+  return await addCalendar({ id: calendarId, name: "" });
 }
 
-export async function selectCalendar(calendarId: string): Promise<void> {
-  await invoke("select_calendar", { calendarId });
+export async function selectCalendar(calendarId: string): Promise<unknown> {
+  return await invoke("select_calendar", { calendarId });
 }
 
 function getInviteCode(calendar: Calendar) {
@@ -144,13 +147,15 @@ export async function findCalendar(
 }
 
 export async function addCalendar(calendar: Calendar) {
-  if (!findCalendar(calendar.id)) {
+  if ((await findCalendar(calendar.id)) === undefined) {
     await db.calendars.add(calendar);
   }
+
+  return;
 }
 
 export async function updateCalendar(calendar: Calendar) {
-    // @TODO: Update calendar.
+  // @TODO: Update calendar.
 }
 
 export async function addEvent(calEvent: CalendarEvent) {
@@ -159,5 +164,4 @@ export async function addEvent(calEvent: CalendarEvent) {
 
 export async function setSelectedCalendar(calendarId: string) {
   // @TODO: Set selected calendar.
-  return;
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -98,9 +98,6 @@ export async function createCalendar(payload: any): Promise<string> {
   // https://github.com/toolkitties/toolkitty/issues/69 is implemented.
   let hash: string = await invoke("create_calendar", { payload });
 
-  // We don't know the name yet, this should be updated when we receive a "calendar_created" event.
-  addCalendar({ id: hash, name: "" });
-
   // Register this operation in the promise map.
   let ready = addPromise(hash);
 
@@ -113,9 +110,10 @@ export async function createCalendar(payload: any): Promise<string> {
 export async function subscribeToCalendar(calendarId: string): Promise<void> {
   await invoke("subscribe_to_calendar", { calendarId });
 
-  if (!findCalendar(calendarId)) {
-    addCalendar({ id: calendarId, name: "" });
-  }
+
+  // @TODO: might be nice for consistency to handle adding a newly subscribed calendar in the
+  // event stream, we'd add a "subscribed_to_calendar" in order to do that.
+  addCalendar({ id: calendarId, name: "" });
 }
 
 export async function selectCalendar(calendarId: string): Promise<void> {
@@ -149,7 +147,9 @@ export async function findCalendar(
 }
 
 export async function addCalendar(calendar: Calendar) {
-  await db.calendars.add(calendar);
+  if (!findCalendar(calendar.id)) {
+    await db.calendars.add(calendar);
+  }
 }
 
 export async function addEvent(calEvent: CalendarEvent) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -97,6 +97,7 @@ export async function createCalendar(payload: any): Promise<string> {
   // happen on the frontend with follow-up IPC calls. This can be refactored when
   // https://github.com/toolkitties/toolkitty/issues/69 is implemented.
   let hash: string = await invoke("create_calendar", { payload });
+  addCalendar({ id: hash, name: null });
 
   // Register this operation in the promise map.
   let ready = addPromise(hash);
@@ -109,11 +110,7 @@ export async function createCalendar(payload: any): Promise<string> {
 
 export async function subscribeToCalendar(calendarId: string): Promise<void> {
   await invoke("subscribe_to_calendar", { calendarId });
-
-
-  // @TODO: might be nice for consistency to handle adding a newly subscribed calendar in the
-  // event stream, we'd add a "subscribed_to_calendar" in order to do that.
-  addCalendar({ id: calendarId, name: "" });
+  addCalendar({ id: calendarId, name: null });
 }
 
 export async function selectCalendar(calendarId: string): Promise<void> {
@@ -150,6 +147,10 @@ export async function addCalendar(calendar: Calendar) {
   if (!findCalendar(calendar.id)) {
     await db.calendars.add(calendar);
   }
+}
+
+export async function updateCalendar(calendar: Calendar) {
+    // @TODO: Update calendar.
 }
 
 export async function addEvent(calEvent: CalendarEvent) {

--- a/src/lib/channel.ts
+++ b/src/lib/channel.ts
@@ -1,9 +1,9 @@
 import { invoke, Channel } from "@tauri-apps/api/core";
 import {
-  addCalendar,
   handleInviteCodeResponse,
   respondInviteCodeRequest,
   setSelectedCalendar,
+  updateCalendar,
 } from "./api";
 import { resolvePromise } from "./promiseMap";
 
@@ -23,10 +23,7 @@ export async function init() {
           name: message.data.data.title,
         };
 
-        addCalendar(calendar);
-
-        console.log("Calendar created: ", calendar);
-
+        updateCalendar(calendar);
         resolvePromise(message.meta.operationId);
       }
 
@@ -44,7 +41,7 @@ export async function init() {
       }
     } else if (message.event === "calendar_selected") {
       await setSelectedCalendar(message.calendarId);
-      console.log("calendar_selected: ", message.calendarId)
+      console.log("calendar_selected: ", message.calendarId);
     }
   };
 

--- a/src/lib/channel.ts
+++ b/src/lib/channel.ts
@@ -3,6 +3,7 @@ import {
   addCalendar,
   handleInviteCodeResponse,
   respondInviteCodeRequest,
+  setSelectedCalendar,
 } from "./api";
 import { resolvePromise } from "./promiseMap";
 
@@ -41,6 +42,9 @@ export async function init() {
       if (message.data.messageType === "response") {
         handleInviteCodeResponse(message.data);
       }
+    } else if (message.event === "calendar_selected") {
+      await setSelectedCalendar(message.calendarId);
+      console.log("calendar_selected: ", message.calendarId)
     }
   };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -59,7 +59,7 @@ type ResolveInviteCodeResponse = {
 // TODO: Finish calendar type
 type Calendar = {
   id: string;
-  name: string | null;
+  name: string;
 };
 
 type Calendars = Calendar[];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -59,7 +59,7 @@ type ResolveInviteCodeResponse = {
 // TODO: Finish calendar type
 type Calendar = {
   id: string;
-  name: string;
+  name: string | null;
 };
 
 type Calendars = Calendar[];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,15 +6,15 @@ type OperationMeta = {
 
 type StreamMessage =
   | {
-    meta: OperationMeta;
-    event: "application";
-    data: ApplicationMessage;
-  }
+      meta: OperationMeta;
+      event: "application";
+      data: ApplicationMessage;
+    }
   | {
-    meta: OperationMeta;
-    event: "error";
-    data: string;
-  };
+      meta: OperationMeta;
+      event: "error";
+      data: string;
+    };
 
 type InviteCodeReadyMessage = {
   event: "invite_codes_ready";
@@ -25,10 +25,16 @@ type InviteCodeMessage = {
   data: ResolveInviteCodeRequest | ResolveInviteCodeResponse;
 };
 
+type CalendarSelected = {
+  event: "calendar_selected";
+  calendarId: string;
+};
+
 type ChannelMessage =
   | StreamMessage
   | InviteCodeReadyMessage
-  | InviteCodeMessage;
+  | InviteCodeMessage
+  | CalendarSelected;
 
 type ApplicationMessage = {
   type: "calendar_created";
@@ -50,16 +56,15 @@ type ResolveInviteCodeResponse = {
   messageType: "response";
 };
 
-
 // TODO: Finish calendar type
 type Calendar = {
   id: string;
   name: string;
-}
+};
 
-type Calendars = Calendar[]
+type Calendars = Calendar[];
 
 type CalendarEvent = {
   id: string;
   name: string;
-}
+};

--- a/src/routes/(unauthed)/+page.svelte
+++ b/src/routes/(unauthed)/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { PinInput, Toggle } from "bits-ui";
   import { goto } from "$app/navigation";
-  import { resolveInviteCode } from "$lib/api";
+  import { resolveInviteCode, selectCalendar, subscribeToCalendar } from "$lib/api";
 
   let value: string[] | undefined = [];
 
@@ -29,6 +29,9 @@
       console.error(err);
       return;
     }
+
+    await selectCalendar(calendarId);
+    await subscribeToCalendar(calendarId);
 
     goto(`/join?code=${calendarId}`);
   }


### PR DESCRIPTION
- [x] add `selected_calendar` field to app state on backend
- [x] filter out all events from the app stream which are not associated with the selected calendar
- [x] introduce `select_calendar` and `subscribe_to_calendar` IPC methods which do what they say
- [x] introduce `calendar_selected` event which is sent to the app when the selected calendar changes
- [x] POC frontend integration 