### PR TITLE
`IPC` methods for subscribing to and selecting calendars  

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3986,7 +3986,7 @@ dependencies = [
 [[package]]
 name = "p2panda-core"
 version = "0.2.0"
-source = "git+https://github.com/p2panda/p2panda?rev=b9818729f95922282e8f4cb8f2fd709314162ce6#b9818729f95922282e8f4cb8f2fd709314162ce6"
+source = "git+https://github.com/p2panda/p2panda?rev=312fe069492db43bcd478835c16b418ed2525bd0#312fe069492db43bcd478835c16b418ed2525bd0"
 dependencies = [
  "blake3",
  "ciborium",
@@ -4001,7 +4001,7 @@ dependencies = [
 [[package]]
 name = "p2panda-discovery"
 version = "0.2.0"
-source = "git+https://github.com/p2panda/p2panda?rev=b9818729f95922282e8f4cb8f2fd709314162ce6#b9818729f95922282e8f4cb8f2fd709314162ce6"
+source = "git+https://github.com/p2panda/p2panda?rev=312fe069492db43bcd478835c16b418ed2525bd0#312fe069492db43bcd478835c16b418ed2525bd0"
 dependencies = [
  "anyhow",
  "flume",
@@ -4020,7 +4020,7 @@ dependencies = [
 [[package]]
 name = "p2panda-net"
 version = "0.2.0"
-source = "git+https://github.com/p2panda/p2panda?rev=b9818729f95922282e8f4cb8f2fd709314162ce6#b9818729f95922282e8f4cb8f2fd709314162ce6"
+source = "git+https://github.com/p2panda/p2panda?rev=312fe069492db43bcd478835c16b418ed2525bd0#312fe069492db43bcd478835c16b418ed2525bd0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4047,7 +4047,7 @@ dependencies = [
 [[package]]
 name = "p2panda-store"
 version = "0.2.0"
-source = "git+https://github.com/p2panda/p2panda?rev=b9818729f95922282e8f4cb8f2fd709314162ce6#b9818729f95922282e8f4cb8f2fd709314162ce6"
+source = "git+https://github.com/p2panda/p2panda?rev=312fe069492db43bcd478835c16b418ed2525bd0#312fe069492db43bcd478835c16b418ed2525bd0"
 dependencies = [
  "p2panda-core",
  "trait-variant",
@@ -4056,7 +4056,7 @@ dependencies = [
 [[package]]
 name = "p2panda-stream"
 version = "0.2.0"
-source = "git+https://github.com/p2panda/p2panda?rev=b9818729f95922282e8f4cb8f2fd709314162ce6#b9818729f95922282e8f4cb8f2fd709314162ce6"
+source = "git+https://github.com/p2panda/p2panda?rev=312fe069492db43bcd478835c16b418ed2525bd0#312fe069492db43bcd478835c16b418ed2525bd0"
 dependencies = [
  "ciborium",
  "futures-channel",
@@ -4071,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "p2panda-sync"
 version = "0.2.0"
-source = "git+https://github.com/p2panda/p2panda?rev=b9818729f95922282e8f4cb8f2fd709314162ce6#b9818729f95922282e8f4cb8f2fd709314162ce6"
+source = "git+https://github.com/p2panda/p2panda?rev=312fe069492db43bcd478835c16b418ed2525bd0#312fe069492db43bcd478835c16b418ed2525bd0"
 dependencies = [
  "async-trait",
  "futures",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,12 +17,12 @@ tauri-build = { version = "2", features = [] }
 anyhow = "1.0.95"
 async-trait = "0.1.85"
 futures-util = "0.3.31"
-p2panda-core = { git = "https://github.com/p2panda/p2panda", rev = "b9818729f95922282e8f4cb8f2fd709314162ce6" }
-p2panda-discovery = { git = "https://github.com/p2panda/p2panda", rev = "b9818729f95922282e8f4cb8f2fd709314162ce6", features = ["mdns"] }
-p2panda-net = { git = "https://github.com/p2panda/p2panda", rev = "b9818729f95922282e8f4cb8f2fd709314162ce6" }
-p2panda-store = { git = "https://github.com/p2panda/p2panda", rev = "b9818729f95922282e8f4cb8f2fd709314162ce6" }
-p2panda-stream = { git = "https://github.com/p2panda/p2panda", rev = "b9818729f95922282e8f4cb8f2fd709314162ce6" }
-p2panda-sync = { git = "https://github.com/p2panda/p2panda", rev = "b9818729f95922282e8f4cb8f2fd709314162ce6", features = ["log-sync"] }
+p2panda-core = { git = "https://github.com/p2panda/p2panda", rev = "312fe069492db43bcd478835c16b418ed2525bd0" }
+p2panda-discovery = { git = "https://github.com/p2panda/p2panda", rev = "312fe069492db43bcd478835c16b418ed2525bd0", features = ["mdns"] }
+p2panda-net = { git = "https://github.com/p2panda/p2panda", rev = "312fe069492db43bcd478835c16b418ed2525bd0" }
+p2panda-store = { git = "https://github.com/p2panda/p2panda", rev = "312fe069492db43bcd478835c16b418ed2525bd0" }
+p2panda-stream = { git = "https://github.com/p2panda/p2panda", rev = "312fe069492db43bcd478835c16b418ed2525bd0" }
+p2panda-sync = { git = "https://github.com/p2panda/p2panda", rev = "312fe069492db43bcd478835c16b418ed2525bd0", features = ["log-sync"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2", features = [] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -267,8 +267,8 @@ async fn forward_to_app_layer(
                     let state = app.state::<Mutex<AppContext>>();
                     let state = state.lock().await;
 
-                    // Check if the event is associated with the currently selected calendar. We
-                    // only forward it up to the application if it is.
+                    // Only send the selected_calendar event to the frontend if we _changed_
+                    // calendar.
                     if state.selected_calendar != selected_calendar {
                         selected_calendar = state.selected_calendar;
 
@@ -278,6 +278,8 @@ async fn forward_to_app_layer(
                         // @TODO: replay all un-acked operations here.
                     }
 
+                    // Check if the event is associated with the currently selected calendar. We
+                    // only forward it up to the application if it is.
                     if let Some(selected_calendar) = selected_calendar {
                         if selected_calendar != meta.calendar_id {
                             return;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -97,15 +97,15 @@ async fn create_calendar(
     let calendar_id = hash.into();
     let topic = NetworkTopic::Calendar { calendar_id };
 
-    // This is a new calendar and so we have never subscribed to it's topic yet. Do this before
-    // actually publishing the create event.
-    state.node.subscribe_processed(&topic).await.unwrap();
-
     // @TODO: It would be clearer if this "selecting" of the calendar was handled by calling the
     // IPC method from the front end. This is not possible until we have re-play of un-acked
     // operations though, as currently there is the chance that operations are missed (and not
     // re-played) if we don't select here.
     state.selected_calendar = Some(calendar_id);
+
+    // This is a new calendar and so we have never subscribed to it's topic yet. Do this before
+    // actually publishing the create event.
+    state.node.subscribe_processed(&topic).await.unwrap();
 
     state
         .node

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -94,13 +94,18 @@ async fn create_calendar(
         create_operation(&mut state.store, &private_key, extensions, Some(&payload)).await;
 
     let hash = header.hash();
-    let topic = NetworkTopic::Calendar {
-        calendar_id: hash.into(),
-    };
+    let calendar_id = hash.into();
+    let topic = NetworkTopic::Calendar { calendar_id };
 
     // This is a new calendar and so we have never subscribed to it's topic yet. Do this before
     // actually publishing the create event.
     state.node.subscribe_processed(&topic).await.unwrap();
+
+    // @TODO: It would be clearer if this "selecting" of the calendar was handled by calling the
+    // IPC method from the front end. This is not possible until we have re-play of un-acked
+    // operations though, as currently there is the chance that operations are missed (and not
+    // re-played) if we don't select here.
+    state.selected_calendar = Some(calendar_id);
 
     state
         .node
@@ -243,6 +248,7 @@ async fn forward_to_app_layer(
     }
 
     rt.spawn(async move {
+        let mut selected_calendar = None;
         loop {
             tokio::select! {
                 Some(event) = stream_rx.recv() => {
@@ -258,11 +264,21 @@ async fn forward_to_app_layer(
                     let StreamEvent { meta, .. } = &event;
                     topic_map.add_author(meta.public_key, meta.calendar_id).await;
 
-                    // Check if the event is associated with the currently selected calendar. We
-                    // only forward it up to the application if it is.
                     let state = app.state::<Mutex<AppContext>>();
                     let state = state.lock().await;
-                    if let Some(selected_calendar) = state.selected_calendar {
+
+                    // Check if the event is associated with the currently selected calendar. We
+                    // only forward it up to the application if it is.
+                    if state.selected_calendar != selected_calendar {
+                        selected_calendar = state.selected_calendar;
+
+                        let calendar_id = selected_calendar.unwrap();
+                        channel.send(ChannelEvent::CalendarSelected(calendar_id)).unwrap();
+
+                        // @TODO: replay all un-acked operations here.
+                    }
+
+                    if let Some(selected_calendar) = selected_calendar {
                         if selected_calendar != meta.calendar_id {
                             return;
                         };
@@ -290,6 +306,7 @@ enum ChannelEvent {
     Stream(StreamEvent),
     InviteCodesReady,
     InviteCodes(serde_json::Value),
+    CalendarSelected(CalendarId),
 }
 
 impl Serialize for ChannelEvent {
@@ -308,6 +325,12 @@ impl Serialize for ChannelEvent {
                 let mut state = serializer.serialize_struct("StreamEvent", 2)?;
                 state.serialize_field("event", "invite_codes")?;
                 state.serialize_field("data", &payload)?;
+                state.end()
+            }
+            ChannelEvent::CalendarSelected(calendar_id) => {
+                let mut state = serializer.serialize_struct("StreamEvent", 2)?;
+                state.serialize_field("event", "calendar_selected")?;
+                state.serialize_field("calendarId", &calendar_id)?;
                 state.end()
             }
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -52,9 +52,9 @@ async fn ack(state: State<'_, Mutex<AppContext>>, operation_id: Hash) -> Result<
 }
 
 #[tauri::command]
-async fn select_calendar(
+async fn subscribe_to_calendar(
     state: State<'_, Mutex<AppContext>>,
-    calendar_id: Hash,
+    calendar_id: CalendarId,
 ) -> Result<(), PublishError> {
     let state = state.lock().await;
     state
@@ -62,6 +62,16 @@ async fn select_calendar(
         .subscribe_processed(&NetworkTopic::Calendar { calendar_id })
         .await
         .unwrap();
+    Ok(())
+}
+
+#[tauri::command]
+async fn select_calendar(
+    state: State<'_, Mutex<AppContext>>,
+    calendar_id: CalendarId,
+) -> Result<(), PublishError> {
+    let mut state = state.lock().await;
+    state.selected_calendar = Some(calendar_id);
     Ok(())
 }
 
@@ -84,7 +94,9 @@ async fn create_calendar(
         create_operation(&mut state.store, &private_key, extensions, Some(&payload)).await;
 
     let hash = header.hash();
-    let topic = NetworkTopic::Calendar { calendar_id: hash };
+    let topic = NetworkTopic::Calendar {
+        calendar_id: hash.into(),
+    };
 
     // This is a new calendar and so we have never subscribed to it's topic yet. Do this before
     // actually publishing the create event.
@@ -202,6 +214,7 @@ pub fn run() {
             publish_calendar_event,
             publish_to_invite_code_overlay,
             select_calendar,
+            subscribe_to_calendar,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/topic.rs
+++ b/src-tauri/src/topic.rs
@@ -24,7 +24,7 @@ pub struct Calendar {
 #[serde(tag = "t", content = "c", rename_all = "snake_case")]
 pub enum NetworkTopic {
     InviteCodes,
-    Calendar { calendar_id: Hash },
+    Calendar { calendar_id: CalendarId },
 }
 
 impl TopicQuery for NetworkTopic {}

--- a/src/lib/api/calendars.ts
+++ b/src/lib/api/calendars.ts
@@ -47,6 +47,11 @@ export async function create(
   data: CalendarCreatedEvent["data"],
 ): Promise<Hash> {
   // Define the "calendar created" application event.
+  //
+  // @TODO: Currently subscribing and selecting the calendar occurs on the backend when this
+  // method is called. It would be more transparent, avoiding hidden side-effects, if this could
+  // happen on the frontend with follow-up IPC calls. This can be refactored when
+  // https://github.com/toolkitties/toolkitty/issues/69 is implemented.
   const payload: CalendarCreatedEvent = {
     type: "calendar_created",
     data,

--- a/src/lib/api/calendars.ts
+++ b/src/lib/api/calendars.ts
@@ -56,6 +56,24 @@ export async function create(
   return hash;
 }
 
+/**
+ * Select a new calendar. This tells the backend to only forward events associated with the passed
+ * calendar to the frontend. Events for any other calendar we are subscribed to will not be
+ * processed by the frontend.
+ */
+export async function select(calendarId: Hash) {
+  await invoke("select_calendar", { calendarId });
+}
+
+/**
+ * Subscribe to a calendar. This tells the backend to subscribe to all topics associated with this
+ * calendar, enter gossip overlays and sync with any discovered peers. It does not effect which
+ * calendar events are forwarded to the frontend.
+ */
+export async function subscribe(calendarId: Hash) {
+  await invoke("subscribe_to_calendar", { calendarId });
+}
+
 /*
  * Processor
  */
@@ -79,14 +97,4 @@ async function onCalendarCreated(
     ownerId: meta.publicKey,
     name: data.name,
   });
-}
-
-// @TODO: move to own module and add doc string
-export async function select(calendarId: Hash) {
-  await invoke("select_calendar", { calendarId });
-}
-
-// @TODO: move to own module and add doc string
-export async function subscribe(calendarId: Hash) {
-  await invoke("subscribe_to_calendar", { calendarId });
 }

--- a/src/lib/api/calendars.ts
+++ b/src/lib/api/calendars.ts
@@ -102,3 +102,13 @@ async function onCalendarCreated(
     name: data.name,
   });
 }
+
+// @TODO: move to own module and add doc string
+export async function select(calendarId: Hash) {
+  await invoke("select_calendar", { calendarId });
+}
+
+// @TODO: move to own module and add doc string
+export async function subscribe(calendarId: Hash) {
+  await invoke("subscribe_to_calendar", { calendarId });
+}

--- a/src/lib/api/inviteCodes.ts
+++ b/src/lib/api/inviteCodes.ts
@@ -6,7 +6,7 @@ type InviteCodesState = {
   onResolved: null | ((resolved: ResolvedCalendar) => void);
 };
 
-type ResolvedCalendar = {
+export type ResolvedCalendar = {
   id: Hash;
   name: string;
 };

--- a/src/lib/api/onboarding.ts
+++ b/src/lib/api/onboarding.ts
@@ -1,0 +1,18 @@
+import { calendars, inviteCodes } from ".";
+import type { ResolvedCalendar } from "./inviteCodes";
+
+
+export async function joinWithInviteCode(
+    inviteCode: string,
+  ): Promise<ResolvedCalendar> {
+    let calendar = await inviteCodes.resolve(inviteCode);
+    await calendars.select(calendar.id);
+    await calendars.subscribe(calendar.id);
+
+    // @TODO: At this point we've "joined" the calendar but we haven't received the
+    // `CalendarCreated` event yet, which will ultimately update our database state when it's
+    // handled by the calendar processor. Is there a transitory state we need to handle here?
+
+    return calendar;
+}
+

--- a/src/lib/channel.ts
+++ b/src/lib/channel.ts
@@ -29,6 +29,8 @@ async function onChannelMessage(message: ChannelMessage) {
     message.event == "invite_codes"
   ) {
     await onInviteCodesMessage(message);
+  } else if (message.event === "calendar_selected") {
+    // @TODO: set selected calendar.
   }
 }
 

--- a/src/lib/channel.ts
+++ b/src/lib/channel.ts
@@ -32,6 +32,12 @@ async function onChannelMessage(message: ChannelMessage) {
   } else if (message.event === "calendar_selected") {
     // @TODO: set selected calendar.
     console.log("calendar selected: ", message.calendarId);
+  } else if (message.event === "subscribed_to_calendar") {
+    // @TODO: handle subscribed_to_calendar event.
+    console.log("subscribed to calendar: ", message.calendarId);
+  } else if (message.event === "calendar_gossip_joined") {
+    // @TODO: handle calendar_gossip_joined event.
+    console.log("joined calendar gossip: ", message.calendarId);
   }
 }
 

--- a/src/lib/channel.ts
+++ b/src/lib/channel.ts
@@ -31,6 +31,7 @@ async function onChannelMessage(message: ChannelMessage) {
     await onInviteCodesMessage(message);
   } else if (message.event === "calendar_selected") {
     // @TODO: set selected calendar.
+    console.log("calendar selected: ", message.calendarId);
   }
 }
 

--- a/src/lib/processor.ts
+++ b/src/lib/processor.ts
@@ -133,6 +133,10 @@ export async function process(message: ChannelMessage) {
     message.event == "invite_codes"
   ) {
     await onInviteCodesMessage(message);
+  } else if (
+    message.event == "calendar_selected" || message.event == "subscribed_to_calendar" || message.event == "calendar_gossip_joined"
+  ) {
+    await onSystemMessage(message);
   }
 }
 
@@ -162,3 +166,18 @@ async function onInviteCodesMessage(
     console.error(`failed processing invite codes message: ${err}`, message);
   }
 }
+
+async function onSystemMessage(
+  message: SystemMessage,
+) {
+  if (message.event === "calendar_selected") {
+    // @TODO: set selected calendar.
+    console.log("calendar selected: ", message.calendarId);
+  } else if (message.event === "subscribed_to_calendar") {
+    console.log("subscribed to calendar: ", message.calendarId);
+  } else if (message.event === "calendar_gossip_joined") {
+    console.log("joined calendar gossip: ", message.calendarId);
+  }
+}
+
+

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,9 +40,7 @@ type ChannelMessage =
   | StreamMessage
   | InviteCodesReadyMessage
   | InviteCodesMessage
-  | CalendarSelected
-  | SubscribedToCalendar
-  | CalendarGossipJoined;
+  | SystemMessage;
 
 /**
  * ଘ(˵╹-╹)━☆•.,¸.•*
@@ -111,14 +109,18 @@ type StreamMessageMeta = {
 
 /**
  * o( ❛ᴗ❛ )o	
- * System Events
+ * System Messages
  */
 
 /**
- * System events occur when an action or event occurred on our own node, they don't represent
+ * System messages occur when an action or event occurred on our own node, they don't represent
  * messages passed around the network. They can be the result of a command being called or some
  * backend state change.
  */
+
+type SystemMessage = CalendarSelected
+  | SubscribedToCalendar
+  | CalendarGossipJoined;
 
 /**
  * We have selected a new calendar and are ready to receive it's events.

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -39,7 +39,8 @@ type Image = string;
 type ChannelMessage =
   | StreamMessage
   | InviteCodesReadyMessage
-  | InviteCodesMessage;
+  | InviteCodesMessage
+  | CalendarSelected;
 
 /**
  * ଘ(˵╹-╹)━☆•.,¸.•*
@@ -104,6 +105,22 @@ type StreamMessageMeta = {
   calendarId: Hash;
   operationId: Hash;
   publicKey: PublicKey;
+};
+
+/**
+ * o( ❛ᴗ❛ )o	
+ * System Events
+ */
+
+/**
+ * System events occur when an action or event occurred on our own node, they don't represent
+ * messages passed around the network. They can be the result of a command being called or some
+ * backend state change.
+ */
+
+type CalendarSelected = {
+  event: "calendar_selected";
+  calendarId: string;
 };
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,7 +40,9 @@ type ChannelMessage =
   | StreamMessage
   | InviteCodesReadyMessage
   | InviteCodesMessage
-  | CalendarSelected;
+  | CalendarSelected
+  | SubscribedToCalendar
+  | CalendarGossipJoined;
 
 /**
  * ଘ(˵╹-╹)━☆•.,¸.•*
@@ -120,6 +122,16 @@ type StreamMessageMeta = {
 
 type CalendarSelected = {
   event: "calendar_selected";
+  calendarId: string;
+};
+
+type SubscribedToCalendar = {
+  event: "subscribed_to_calendar";
+  calendarId: string;
+};
+
+type CalendarGossipJoined = {
+  event: "calendar_gossip_joined";
   calendarId: string;
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -120,16 +120,26 @@ type StreamMessageMeta = {
  * backend state change.
  */
 
+/**
+ * We have selected a new calendar and are ready to receive it's events.
+ */
 type CalendarSelected = {
   event: "calendar_selected";
   calendarId: string;
 };
 
+/**
+ * We have successfully subscribed to (but not necessarily selected) a new calendar.
+ */
 type SubscribedToCalendar = {
   event: "subscribed_to_calendar";
   calendarId: string;
 };
 
+/**
+ * We joined a gossip overlay of a calendar we are subscribed to. This occurs when we meet a peer
+ * subscribed to the same calendar.
+ */
 type CalendarGossipJoined = {
   event: "calendar_gossip_joined";
   calendarId: string;

--- a/src/routes/(unauthed)/+page.svelte
+++ b/src/routes/(unauthed)/+page.svelte
@@ -4,6 +4,7 @@
   import { inviteCodes, calendars } from "$lib/api";
   import { db } from "$lib/db";
   import { appConfigDir } from "@tauri-apps/api/path";
+  import { joinWithInviteCode } from "$lib/api/onboarding";
 
   let value: string[] | undefined = [];
 
@@ -23,20 +24,13 @@
     let calendar;
     try {
       progress = "pending";
-      // @TODO: We probably want a "higher-level" API method here which handles
-      // the whole "joinExistingCalendar" onboarding flow by 1. resolve invite
-      // code 2. add resolved calendar to database & set it to "active" 3.
-      // maybe more ..
-      calendar = await inviteCodes.resolve(value.join(""));
+      calendar = await joinWithInviteCode(value.join(""));
     } catch (err) {
       timedOut = true;
       progress = "dormant";
       console.error(err);
       return;
     }
-
-    await calendars.select(calendar.id);
-    await calendars.subscribe(calendar.id);
 
     goto(`/join?code=${calendar.id}`);
   }

--- a/src/routes/(unauthed)/+page.svelte
+++ b/src/routes/(unauthed)/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import { PinInput, Toggle } from "bits-ui";
   import { goto } from "$app/navigation";
-  import { inviteCodes } from "$lib/api";
+  import { inviteCodes, calendars } from "$lib/api";
   import { db } from "$lib/db";
+  import { appConfigDir } from "@tauri-apps/api/path";
 
   let value: string[] | undefined = [];
 
@@ -33,6 +34,9 @@
       console.error(err);
       return;
     }
+
+    await calendars.select(calendar.id);
+    await calendars.subscribe(calendar.id);
 
     goto(`/join?code=${calendar.id}`);
   }


### PR DESCRIPTION
- [x] add `selected_calendar` and `subscriptions` fields to app state on backend
- [x] filter out all events from the app stream which are not associated with the selected calendar 
- [x] introduce `select_calendar` and `subscribe_to_calendar` IPC methods with matching channel events
- [x] BONUS: use new system events channel to inform the frontend when the calendar gossip overlay is joined 
- [x] POC frontend integration 