### PR TITLE
Define protocol message types

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -363,6 +363,9 @@ type PageUpdated = {
 
 type CalendarDeleted = {
   type: "calendar_deleted";
+  data: {
+    id: Hash;
+  };
 };
 
 /**
@@ -386,6 +389,9 @@ type SpaceUpdated = {
 
 type SpaceDeleted = {
   type: "space_deleted";
+  data: {
+    id: Hash;
+  };
 };
 
 /**
@@ -409,6 +415,9 @@ type ResourceUpdated = {
 
 type ResourceDeleted = {
   type: "resource_deleted";
+  data: {
+    id: Hash;
+  };
 };
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -212,7 +212,7 @@ type ResolveInviteCodeResponse = {
  */
 
 type ApplicationEvent =
-  | UserNameAssigned
+  | UserProfileUpdated
   | CalendarCreated
   | CalendarUpdated
   | CalendarDeleted
@@ -220,6 +220,7 @@ type ApplicationEvent =
   | CalendarAccessAccepted
   | CalendarAccessRejected
   | CalendarAccessRejected
+  | PageUpdated
   | SpaceCreated
   | SpaceUpdated
   | SpaceDeleted
@@ -352,23 +353,10 @@ type CalendarUpdated = {
   };
 };
 
-type SpacesPageDescriptionUpdated = {
-  type: "space_page_description_updated";
+type PageUpdated = {
+  type: "page_updated";
   data: {
-    description: string;
-  };
-};
-
-type ResourcesPageDescriptionUpdated = {
-  type: "space_page_description_updated";
-  data: {
-    description: string;
-  };
-};
-
-type AboutPageDescriptionUpdated = {
-  type: "space_page_description_updated";
-  data: {
+    page_type: "spaces" | "resources" | "about";
     description: string;
   };
 };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -232,10 +232,12 @@ type ApplicationEvent =
   | SpaceRequested
   | SpaceRequestAccepted
   | SpaceRequestRejected
+  | SpaceRequestCancelled
   | SpaceRequestAcceptanceRevoked
   | ResourceRequested
   | ResourceRequestAccepted
   | ResourceRequestRejected
+  | ResourceRequestCancelled
   | ResourceRequestAcceptanceRevoked
   | UserRoleAssigned;
 
@@ -476,6 +478,13 @@ type SpaceRequestRejected = {
   };
 };
 
+type SpaceRequestCancelled = {
+  type: "space_request_cancelled";
+  data: {
+    requestId: Hash;
+  };
+};
+
 type SpaceRequestAcceptanceRevoked = {
   type: "space_request_acceptance_revoked";
   data: {
@@ -502,6 +511,13 @@ type ResourceRequestAccepted = {
 
 type ResourceRequestRejected = {
   type: "resource_request_rejected";
+  data: {
+    requestId: Hash;
+  };
+};
+
+type ResourceRequestCancelled = {
+  type: "resource_request_cancelled";
   data: {
     requestId: Hash;
   };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -375,7 +375,7 @@ type CalendarDeleted = {
 type SpaceCreated = {
   type: "space_created";
   data: {
-    field: SpaceFields;
+    fields: SpaceFields;
   };
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -108,7 +108,7 @@ type StreamMessageMeta = {
 };
 
 /**
- * o( ❛ᴗ❛ )o	
+ * o( ❛ᴗ❛ )o
  * System Messages
  */
 
@@ -118,7 +118,8 @@ type StreamMessageMeta = {
  * backend state change.
  */
 
-type SystemMessage = CalendarSelected
+type SystemMessage =
+  | CalendarSelected
   | SubscribedToCalendar
   | CalendarGossipJoined;
 
@@ -209,14 +210,319 @@ type ResolveInviteCodeResponse = {
  * similar words for this), we've created or changed our application data
  * which is further defined below.
  */
-type ApplicationEvent = CalendarCreatedEvent;
 
-type CalendarCreatedEvent = {
-  type: "calendar_created";
+type ApplicationEvent =
+  | UserNameAssigned
+  | CalendarCreated
+  | CalendarUpdated
+  | CalendarDeleted
+  | CalendarAccessRequested
+  | CalendarAccessAccepted
+  | CalendarAccessRejected
+  | CalendarAccessRejected
+  | SpaceCreated
+  | SpaceUpdated
+  | SpaceDeleted
+  | ResourceCreated
+  | ResourceUpdated
+  | ResourceDeleted
+  | EventCreated
+  | EventUpdated
+  | EventDeleted
+  | SpaceRequested
+  | SpaceRequestAccepted
+  | SpaceRequestRejected
+  | SpaceRequestAcceptanceRevoked
+  | ResourceRequested
+  | ResourceRequestAccepted
+  | ResourceRequestRejected
+  | ResourceRequestAcceptanceRevoked
+  | UserRoleAssigned;
+
+/**
+ * Reused types
+ */
+
+type SpaceRequestId = Hash;
+type ResourceRequestId = Hash;
+
+type CalendarFields = {
+  calendarName: string;
+  calendarDates: TimeSpan[];
+};
+
+type SpaceFields = {
+  type: "physical" | "gps" | "virtual";
+  name: string;
+  location: PhysicalLocation | GPSLocation | VirtualLocation;
+  capacity: number;
+  accessibility: string;
+  description: string;
+  contact: string;
+  message: string;
+  link: Link;
+  images: Image[];
+  availability: TimeSpan[] | "always";
+  multiBookable: boolean;
+};
+
+type ResourceFields = {
+  name: string;
+  ownerId: PublicKey;
+  description: string;
+  contact: string;
+  link: Link;
+  images: Image[];
+  availability: TimeSpan[] | "always";
+  multiBookable: boolean; // resource can be booked more than once in the same time span
+};
+
+type EventFields = {
+  name: string;
+  description: string;
+  location?: SpaceRequestId; // ref to a space
+  startDate: Date; // allocated time of a space
+  endDate: Date; // allocated time of a space
+  publicStartDate?: Date; // public facing
+  publicEndDate?: Date; // public facing
+  resources: ResourceRequestId[];
+  links: Link[];
+  images: Image[];
+};
+
+/**
+ * User
+ *
+ * NOTE: sent on `inbox` channel
+ */
+
+type UserNameAssigned = {
+  type: "user_name_assigned";
   data: {
     name: string;
-    startDate?: string;
-    endDate?: string;
+  };
+};
+
+/**
+ * Access
+ *
+ * NOTE: sent on `inbox` channel
+ */
+
+type CalendarAccessRequested = {
+  type: "calendar_access_requested";
+  data: {
+    calendarId: Hash;
+    name: string;
+    message: string;
+  };
+};
+
+type CalendarAccessAccepted = {
+  type: "calendar_access_accepted";
+  data: {
+    calendarId: Hash;
+  };
+};
+
+type CalendarAccessRejected = {
+  type: "calendar_access_rejected";
+  data: {
+    calendarId: Hash;
+  };
+};
+
+/**
+ * Calendar
+ */
+
+type CalendarCreated = {
+  type: "calendar_created";
+  data: {
+    fields: CalendarFields;
+  };
+};
+
+type CalendarUpdated = {
+  type: "calendar_updated";
+  data: {
+    id: Hash;
+    fields: CalendarFields;
+  };
+};
+
+type SpacesPageDescriptionUpdated = {
+  type: "space_page_description_updated";
+  data: {
+    description: string;
+  };
+};
+
+type ResourcesPageDescriptionUpdated = {
+  type: "space_page_description_updated";
+  data: {
+    description: string;
+  };
+};
+
+type AboutPageDescriptionUpdated = {
+  type: "space_page_description_updated";
+  data: {
+    description: string;
+  };
+};
+
+type CalendarDeleted = {
+  type: "calendar_deleted";
+};
+
+/**
+ * Space
+ */
+
+type SpaceCreated = {
+  type: "space_created";
+  data: {
+    field: SpaceFields;
+  };
+};
+
+type SpaceUpdated = {
+  type: "space_updated";
+  data: {
+    id: Hash;
+    fields: SpaceFields;
+  };
+};
+
+type SpaceDeleted = {
+  type: "space_deleted";
+};
+
+/**
+ * Resource
+ */
+
+type ResourceCreated = {
+  type: "resource_created";
+  data: {
+    fields: ResourceFields;
+  };
+};
+
+type ResourceUpdated = {
+  type: "space_updated";
+  data: {
+    id: Hash;
+    fields: ResourceFields;
+  };
+};
+
+type ResourceDeleted = {
+  type: "resource_deleted";
+};
+
+/**
+ * Event
+ */
+
+type EventCreated = {
+  type: "event_created";
+  data: {
+    fields: EventFields;
+  };
+};
+
+type EventUpdated = {
+  type: "event_updated";
+  data: {
+    id: Hash;
+    fields: EventFields;
+  };
+};
+
+type EventDeleted = {
+  type: "event_deleted";
+  data: {
+    id: Hash;
+  };
+};
+
+/**
+ * Requests and responses
+ */
+
+type SpaceRequested = {
+  type: "space_requested";
+  data: {
+    eventId: Hash;
+    spaceId: Hash;
+    message: string;
+    timePeriod: TimeSpan[];
+  };
+};
+
+type SpaceRequestAccepted = {
+  type: "space_request_accepted";
+  data: {
+    requestId: Hash;
+  };
+};
+
+type SpaceRequestRejected = {
+  type: "space_request_rejected";
+  data: {
+    requestId: Hash;
+  };
+};
+
+type SpaceRequestAcceptanceRevoked = {
+  type: "space_request_acceptance_revoked";
+  data: {
+    requestAcceptanceId: Hash;
+  };
+};
+
+type ResourceRequested = {
+  type: "resource_requested";
+  data: {
+    resourceId: Hash;
+    eventId: Hash;
+    message: string;
+    timeSpan: TimeSpan;
+  };
+};
+
+type ResourceRequestAccepted = {
+  type: "resource_request_accepted";
+  data: {
+    requestId: Hash;
+  };
+};
+
+type ResourceRequestRejected = {
+  type: "resource_request_rejected";
+  data: {
+    requestId: Hash;
+  };
+};
+
+type ResourceRequestAcceptanceRevoked = {
+  type: "resource_request_acceptance_revoked";
+  data: {
+    requestAcceptanceId: Hash;
+  };
+};
+
+/**
+ * Roles
+ */
+
+type UserRoleAssigned = {
+  type: "user_role_assigned";
+  data: {
+    publicKey: PublicKey;
+    role: "publisher" | "organiser" | "admin";
   };
 };
 
@@ -224,6 +530,8 @@ type CalendarCreatedEvent = {
  * (´ヮ´)八(*ﾟ▽ﾟ*)
  * Application Data
  */
+
+// @TODO: some updates required here based on the new protocol message definitions above
 
 type User = {
   id: PublicKey;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -465,6 +465,11 @@ type SpaceRequestRejected = {
   };
 };
 
+/**
+ * Message for explicitly cancelling a previously issued space request. Should not be used when a
+ * request can be considered implicitly cancelled due to event deletion or other changes which may
+ * impact existing requests.
+ */
 type SpaceRequestCancelled = {
   type: "space_request_cancelled";
   data: {
@@ -472,6 +477,11 @@ type SpaceRequestCancelled = {
   };
 };
 
+/**
+ * Message for explicitly revoking a previously accepted space request. Should not be used when a
+ * request can be considered implicitly revoked due to space deletion or other changes which may
+ * impact existing requests.
+ */
 type SpaceRequestAcceptanceRevoked = {
   type: "space_request_acceptance_revoked";
   data: {
@@ -503,6 +513,11 @@ type ResourceRequestRejected = {
   };
 };
 
+/**
+ * Message for explicitly cancelling a previously issued resource request. Should not be used when a
+ * request can be considered implicitly cancelled due to event deletion or other changes which may
+ * impact existing requests.
+ */
 type ResourceRequestCancelled = {
   type: "resource_request_cancelled";
   data: {
@@ -510,6 +525,11 @@ type ResourceRequestCancelled = {
   };
 };
 
+/**
+ * Message for explicitly revoking a previously accepted resource request. Should not be used when a
+ * request can be considered implicitly revoked due to resource deletion or other changes which may
+ * impact existing requests.
+ */
 type ResourceRequestAcceptanceRevoked = {
   type: "resource_request_acceptance_revoked";
   data: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -297,8 +297,8 @@ type EventFields = {
  * NOTE: sent on `inbox` channel
  */
 
-type UserNameAssigned = {
-  type: "user_name_assigned";
+type UserProfileUpdated = {
+  type: "user_profile_updated";
   data: {
     name: string;
   };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -270,7 +270,6 @@ type SpaceFields = {
 
 type ResourceFields = {
   name: string;
-  ownerId: PublicKey;
   description: string;
   contact: string;
   link: Link;


### PR DESCRIPTION
Introduce all protocol message types in `types.ts`.

These are the actual protocol message which peers publish and broadcast to all other peers in their network. Processing all messages a peer knows about will result in local state which represents the "current" state of the application. Processing any of these events a second time should not change the state. We don't introduce any of this "processing" logic in this PR, but the required properties should be kept in mind.