### PR TITLE
API endpoints

### DIFF
--- a/src/lib/api/calendars.ts
+++ b/src/lib/api/calendars.ts
@@ -7,14 +7,14 @@ import { liveQuery } from "dexie";
  * Queries
  */
 
-export async function getAll(): Promise<Calendar[]> {
+export async function findMany(): Promise<Calendar[]> {
   return await db.calendars.toArray();
 }
 
 export async function findByInviteCode(
   code: string,
 ): Promise<undefined | Calendar> {
-  const calendars = await getAll();
+  const calendars = await findMany();
   return calendars.find((calendar) => {
     return inviteCode(calendar) === code;
   });

--- a/src/lib/api/data.ts
+++ b/src/lib/api/data.ts
@@ -1,0 +1,128 @@
+export const resources: Resource[] = [
+  {
+    id: "1",
+    name: "Projector",
+    ownerId: "1",
+    description: "Epson CO-FH01 Full HD Projector",
+    contact: "Signal @beamer",
+    availability: [
+      {
+        "start": new Date('2025-01-20T00:0:00Z'),
+        "end": new Date('2025-01-22T00:0:00Z'),
+      },
+      {
+        "start": new Date('2025-01-24T00:0:00Z'),
+        "end": new Date('2025-01-26T00:0:00Z'),
+      }
+    ],
+    quantity: 1,
+    images: ["https://placecats.com/neo_banana/300/200", "https://placecats.com/neo_2/300/200"]
+  },
+  {
+    id: '2',
+    name: "XLR Cables",
+    description: "as above. Call me to confirm pick up",
+    availability: [
+      {
+        "start": new Date('2025-01-01T00:0:00Z'),
+        "end": new Date('2025-02-30T00:0:00Z'),
+      }
+    ],
+    quantity: 10,
+    images: []
+  }
+]
+
+export const spaces: Space[] = [
+  {
+    id: '1',
+    type: "physical",
+    ownerId: '1',
+    name: "Main Stage",
+    location: "123 Street Street",
+    capacity: 200,
+    accessibility: "Wheelchair accessible",
+    description: "A stage, a main one",
+    contact: "Message on Signal",
+    link: {
+      type: 'custom',
+      title: 'Venue website',
+      url: "www.somewebsite.com"
+    },
+    images: ["https://placecats.com/neo_banana/300/200", "https://placecats.com/neo_2/300/200"],
+    availability: [
+      {
+        "start": new Date('2025-01-01T00:0:00Z'),
+        "end": new Date('2025-02-30T00:0:00Z'),
+      }
+    ],
+    multiBookable: false,
+    booked: []
+  },
+  {
+    id: '2',
+    type: "physical",
+    ownerId: '2',
+    name: "Recording Studio",
+    location: "34 Road Avenue",
+    capacity: 20,
+    accessibility: "www.website.com/accessibility",
+    description: "A small recording studio with lots of equipment, that sounds good.",
+    contact: "Message via email",
+    link: {
+      type: 'custom',
+      title: 'Venue website',
+      url: "www.somewebsite.com"
+    },
+    images: ["https://placecats.com/neo_banana/300/200", "https://placecats.com/neo_2/300/200"],
+    availability: [
+      {
+        "start": new Date('2025-01-01T00:0:00Z'),
+        "end": new Date('2025-02-30T00:0:00Z'),
+      }
+    ],
+    multiBookable: false,
+    booked: []
+  },
+]
+
+export const events: CalendarEvent[] = [
+  {
+    id: '1',
+    title: 'Kitty Fest 25',
+    description: 'A grand music festival with various artists.',
+    date: '2025-01-06T14:40:02.536Z',
+    start_time: '19:00',
+    end_time: '21:30',
+    startDate: new Date('2025-01-06T14:0:00Z'),
+    endDate: new Date('2025-01-06T20:00:00Z'),
+    location: {
+      space: spaces[0],
+      response: {
+        id: '1',
+        answer: 'approve',
+      },
+    },
+    image: 'https://placecats.com/louie/300/200',
+    tags: ['music', 'festival', 'cats'],
+  },
+  {
+    id: '2',
+    title: 'Art Exhibition',
+    description: 'An exhibition showcasing modern art.',
+    date: '2025-02-10T10:00:00.000Z',
+    start_time: '10:00',
+    end_time: '17:00',
+    startDate: new Date('2025-02-10T10:00:00.000Z'),
+    endDate: new Date('2025-02-10T17:00:00.000Z'),
+    location: {
+      space: spaces[1],
+      response: {
+        id: '1',
+        answer: 'approve',
+      },
+    },
+    image: 'https://placecats.com/bella/300/200',
+    tags: ['dancing', 'anarchism', 'improvisation'],
+  },
+]

--- a/src/lib/api/data.ts
+++ b/src/lib/api/data.ts
@@ -118,11 +118,28 @@ export const events: CalendarEvent[] = [
     location: {
       space: spaces[1],
       response: {
-        id: '1',
+        id: '3',
         answer: 'approve',
       },
     },
     image: 'https://placecats.com/bella/300/200',
     tags: ['dancing', 'anarchism', 'improvisation'],
   },
+]
+
+export const requests: SpaceRequest[] = [
+  {
+    id: '1',
+    eventId: '2',
+    spaceId: '2',
+    message: 'Require a big main stage for the big band (*-ω-)',
+    response: null
+  },
+  {
+    id: '2',
+    eventId: '2',
+    spaceId: '2',
+    message: 'recording our album and need a good sounding studio ( ＾∇＾)',
+    response: null
+  }
 ]

--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -8,7 +8,7 @@ import { events } from '$lib/api/data'
 /**
  * Get events that are associated with the currently active calendar
  */
-export async function find(): Promise<CalendarEvent[]> {
+export async function findMany(): Promise<CalendarEvent[]> {
   //TODO: Return events from db as liveQuery and add params
   // return test data.
   return events

--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -53,7 +53,7 @@ export async function update(data: CalendarEvent) {
   return '123';
 }
 
-async function remove(id: string) {
+async function deleteEvent(id: string) {
   //TODO: send to backend for processing, add to promise map and await.
 
   // for now we are just returning a hash.
@@ -61,7 +61,7 @@ async function remove(id: string) {
 }
 
 //TODO: Move to class so we don't have to export as an alias
-export { remove as delete };
+export { deleteEvent as delete };
 
 
 //TODO: Add processor

--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -53,12 +53,15 @@ export async function update(data: CalendarEvent) {
   return '123';
 }
 
-export async function remove(id: string) {
+async function remove(id: string) {
   //TODO: send to backend for processing, add to promise map and await.
 
   // for now we are just returning a hash.
   return '123';
 }
+
+//TODO: Move to class so we don't have to export as an alias
+export { remove as delete };
 
 
 //TODO: Add processor

--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -53,7 +53,7 @@ export async function update(data: CalendarEvent) {
   return '123';
 }
 
-async function deleteEvent(id: string) {
+async function deleteEvent(id: Hash) {
   //TODO: send to backend for processing, add to promise map and await.
 
   // for now we are just returning a hash.

--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -1,9 +1,64 @@
-// import { db } from "$lib/db";
+import { events } from '$lib/api/data'
 
-export async function get(id: string) {}
+/**
+ * Queries
+ */
 
-export async function create(event: CalendarEvent) {}
 
-export async function update(event: CalendarEvent) {}
+/**
+ * Get events that are associated with the currently active calendar
+ */
+export async function find(): Promise<CalendarEvent[]> {
+  //TODO: Return events from db as liveQuery and add params
+  // return test data.
+  return events
+}
 
-export async function remove(id: string) {}
+/**
+ * Get all events that I am the owner of.
+ */
+export async function findMine(): Promise<CalendarEvent[]> {
+  //TODO: Return events from db with ownerId that is equal to users public key.
+  // return test data.
+  return events
+}
+
+/**
+ * Get one event via its id
+ */
+export async function findById(id: Hash): Promise<CalendarEvent> {
+  //TODO: Return events from db
+
+  // return test data.
+  return events[0]
+}
+
+
+/**
+ * Commands
+ */
+
+
+export async function create(data: CalendarEvent) {
+  //TODO: send to backend for processing, add to promise map and await.
+
+  // for now we are just returning a hash.
+  return '123';
+}
+
+export async function update(data: CalendarEvent) {
+  //TODO: send to backend for processing, add to promise map and await.
+
+  // for now we are just returning a hash.
+  return '123';
+}
+
+export async function remove(id: string) {
+  //TODO: send to backend for processing, add to promise map and await.
+
+  // for now we are just returning a hash.
+  return '123';
+}
+
+
+//TODO: Add processor

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,3 +1,6 @@
 export * as calendars from "./calendars";
 export * as events from "./events";
 export * as inviteCodes from "./inviteCodes";
+export * as spaces from "./spaces";
+export * as resources from "./resources";
+export * as requests from "./requests";

--- a/src/lib/api/requests.ts
+++ b/src/lib/api/requests.ts
@@ -1,4 +1,4 @@
-import { resources } from '$lib/api/data'
+import { requests } from '$lib/api/data'
 
 /**
  * Queries
@@ -8,21 +8,21 @@ import { resources } from '$lib/api/data'
 /**
  * Get all requests that are pending and associated with user public key
  */
-export async function findPending(): Promise<Resource[]> {
+export async function findPending(): Promise<SpaceRequest[]> {
   //TODO: Return events from db as liveQuery
 
   // return test data.
-  return resources
+  return requests
 }
 
 /**
  * Get one request by its ID
  */
-export async function findById(id: Hash): Promise<Resource> {
+export async function findById(id: Hash): Promise<SpaceRequest> {
   //TODO: Return events from db
 
   // return test data.
-  return resources[0]
+  return requests[0]
 }
 
 

--- a/src/lib/api/requests.ts
+++ b/src/lib/api/requests.ts
@@ -1,0 +1,30 @@
+import { resources } from '$lib/api/data'
+
+/**
+ * Queries
+ */
+
+
+/**
+ * Get all requests that are pending and associated with user public key
+ */
+export async function findPending(): Promise<Resource[]> {
+  //TODO: Return events from db as liveQuery
+
+  // return test data.
+  return resources
+}
+
+/**
+ * Get one request by its ID
+ */
+export async function findById(id: Hash): Promise<Resource> {
+  //TODO: Return events from db
+
+  // return test data.
+  return resources[0]
+}
+
+
+//TODO: Add commands
+//TODO: Add processor

--- a/src/lib/api/requests.ts
+++ b/src/lib/api/requests.ts
@@ -6,7 +6,7 @@ import { requests } from '$lib/api/data'
 
 
 /**
- * Get all requests that are pending and associated with user public key
+ * Get all requests that are pending
  */
 export async function findPending(): Promise<SpaceRequest[]> {
   //TODO: Return events from db as liveQuery

--- a/src/lib/api/resources.ts
+++ b/src/lib/api/resources.ts
@@ -55,7 +55,7 @@ export async function update(data: Resource) {
   return '123';
 }
 
-async function remove(id: string) {
+async function deleteResource(id: string) {
   //TODO: send to backend for processing, add to promise map and await.
 
   // for now we are just returning a hash.
@@ -63,7 +63,7 @@ async function remove(id: string) {
 }
 
 //TODO: Move to class so we don't have to export as an alias
-export { remove as delete };
+export { deleteResource as delete };
 
 
 //TODO: Add processor

--- a/src/lib/api/resources.ts
+++ b/src/lib/api/resources.ts
@@ -8,7 +8,7 @@ import { resources } from '$lib/api/data'
 /**
  * Get resources that are associated with the currently active calendar
  */
-export async function find(): Promise<Resource[]> {
+export async function findMany(): Promise<Resource[]> {
   //TODO: Return resources from db as liveQuery and add params
 
   // return test data.

--- a/src/lib/api/resources.ts
+++ b/src/lib/api/resources.ts
@@ -55,12 +55,15 @@ export async function update(data: Resource) {
   return '123';
 }
 
-export async function remove(id: string) {
+async function remove(id: string) {
   //TODO: send to backend for processing, add to promise map and await.
 
   // for now we are just returning a hash.
   return '123';
 }
+
+//TODO: Move to class so we don't have to export as an alias
+export { remove as delete };
 
 
 //TODO: Add processor

--- a/src/lib/api/resources.ts
+++ b/src/lib/api/resources.ts
@@ -55,7 +55,7 @@ export async function update(data: Resource) {
   return '123';
 }
 
-async function deleteResource(id: string) {
+async function deleteResource(id: Hash) {
   //TODO: send to backend for processing, add to promise map and await.
 
   // for now we are just returning a hash.

--- a/src/lib/api/resources.ts
+++ b/src/lib/api/resources.ts
@@ -1,7 +1,66 @@
-export async function get(id: string) {}
+import { resources } from '$lib/api/data'
 
-export async function add() {}
+/**
+ * Queries
+ */
 
-export async function update() {}
 
-export async function remove(id: string) {}
+/**
+ * Get resources that are associated with the currently active calendar
+ */
+export async function find(): Promise<Resource[]> {
+  //TODO: Return resources from db as liveQuery and add params
+
+  // return test data.
+  return resources
+}
+
+/**
+ * Get all resources that I am the owner of.
+ */
+export async function findMine(): Promise<Resource[]> {
+  //TODO: Return resources from db with ownerId that is equal to users public key.
+
+  // return test data.
+  return resources
+}
+
+/**
+ * Get one event by its ID
+ */
+export async function findById(id: Hash): Promise<Resource> {
+  //TODO: Return events from db
+
+  // return test data.
+  return resources[0]
+}
+
+
+/**
+ * Commands
+ */
+
+
+export async function create(data: Resource) {
+  //TODO: send to backend for processing, add to promise map and await.
+
+  // for now we are just returning a hash.
+  return '123';
+}
+
+export async function update(data: Resource) {
+  //TODO: send to backend for processing, add to promise map and await.
+
+  // for now we are just returning a hash.
+  return '123';
+}
+
+export async function remove(id: string) {
+  //TODO: send to backend for processing, add to promise map and await.
+
+  // for now we are just returning a hash.
+  return '123';
+}
+
+
+//TODO: Add processor

--- a/src/lib/api/spaces.ts
+++ b/src/lib/api/spaces.ts
@@ -55,7 +55,7 @@ export async function update(data: Space) {
   return '123';
 }
 
-export async function remove(id: string) {
+export async function deleteSpace(id: string) {
   //TODO: send to backend for processing, add to promise map and await.
 
   // for now we are just returning a hash.
@@ -63,6 +63,6 @@ export async function remove(id: string) {
 }
 
 //TODO: Move to class so we don't have to export as an alias
-export { remove as delete };
+export { deleteSpace as delete };
 
 //TODO: Add processor

--- a/src/lib/api/spaces.ts
+++ b/src/lib/api/spaces.ts
@@ -1,0 +1,66 @@
+import { spaces } from '$lib/api/data'
+
+/**
+ * Queries
+ */
+
+
+/**
+ * Get spaces that are associated with the currently active calendar
+ */
+export async function find(): Promise<Space[]> {
+  //TODO: Return spaces from db as liveQuery and add params
+
+  // return test data.
+  return spaces
+}
+
+/**
+ * Get all spaces that I am the owner of.
+ */
+export async function findMine(): Promise<Space[]> {
+  //TODO: Return spaces from db with ownerId that is equal to users public key.
+
+  // return test data.
+  return spaces
+}
+
+/**
+ * Get one event by its ID
+ */
+export async function findById(id: Hash): Promise<Space> {
+  // TODO: Return events from db
+
+  // return test data.
+  return spaces[0]
+}
+
+
+/**
+ * Commands
+ */
+
+
+export async function create(data: Space) {
+  //TODO: send to backend for processing, add to promise map and await.
+
+  // for now we are just returning a hash.
+  return '123';
+}
+
+export async function update(data: Space) {
+  //TODO: send to backend for processing, add to promise map and await.
+
+  // for now we are just returning a hash.
+  return '123';
+}
+
+export async function remove(id: string) {
+  //TODO: send to backend for processing, add to promise map and await.
+
+  // for now we are just returning a hash.
+  return '123';
+}
+
+
+//TODO: Add processor

--- a/src/lib/api/spaces.ts
+++ b/src/lib/api/spaces.ts
@@ -62,5 +62,7 @@ export async function remove(id: string) {
   return '123';
 }
 
+//TODO: Move to class so we don't have to export as an alias
+export { remove as delete };
 
 //TODO: Add processor

--- a/src/lib/api/spaces.ts
+++ b/src/lib/api/spaces.ts
@@ -55,7 +55,7 @@ export async function update(data: Space) {
   return '123';
 }
 
-export async function deleteSpace(id: string) {
+export async function deleteSpace(id: Hash) {
   //TODO: send to backend for processing, add to promise map and await.
 
   // for now we are just returning a hash.

--- a/src/lib/api/spaces.ts
+++ b/src/lib/api/spaces.ts
@@ -8,7 +8,7 @@ import { spaces } from '$lib/api/data'
 /**
  * Get spaces that are associated with the currently active calendar
  */
-export async function find(): Promise<Space[]> {
+export async function findMany(): Promise<Space[]> {
   //TODO: Return spaces from db as liveQuery and add params
 
   // return test data.

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -1,0 +1,30 @@
+// const storedActiveCalendar: Hash | null = localStorage.getItem("activeCalendar");
+
+// export const settings = $state<{ activeCalendar: Hash | null, }>({
+//   activeCalendar: null
+// })
+
+// settings.subscribe(value => {
+// })
+
+// class Settings {
+//   activeCalendar: Hash | null = $state(null);
+//   theme: "light" | "dark" = $state("light");
+//   currentPage: string | null = $state(null);
+
+//   setActiveCalendar(id: Hash) {
+//     this.activeCalendar = id;
+//     localStorage.setItem("activeCalendar", id);
+//   }
+
+//   getActiveCalendar() {
+//     localStorage.getItem("activeCalendar");
+//   }
+
+//   setCurrentPage(page: string) {
+//     this.currentPage = page
+//   }
+// }
+
+// export const settings = new Settings();
+


### PR DESCRIPTION
This PR adds new endpoints to the API and returns fake festival data for the frontend to consume.

New endpoints added:

```
events.findMany()
events.findMine()
events.findById()
events.create()
events.update()
events.delete()
```

```
spaces.findMany()
spaces.findMine()
spaces.findById()
spaces.create()
spaces.update()
spaces.delete()
```

```
resources.findMany()
resources.findMine()
resources.findById()
resources.create()
resources.update()
resources.delete()
```

```
requests.findPending()
requests.findById()
```

Still to do
- return/save data to the db
- implement queries on `findMany()`
- Add more endpoints as this is not exhaustive yet.