### PR TITLE
Handle `TopicMap` update on frontend

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod messages;
 mod node;
 mod topic;
 
+use rpc::add_calendar_author;
 use tauri::Builder;
 
 use crate::rpc::{
@@ -28,6 +29,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             init,
             ack,
+            add_calendar_author,
             create_calendar,
             publish_calendar_event,
             publish_to_invite_code_overlay,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,7 +1,7 @@
-mod rpc;
 mod app;
 mod messages;
 mod node;
+mod rpc;
 mod topic;
 
 use rpc::add_calendar_author;

--- a/src-tauri/src/node/mod.rs
+++ b/src-tauri/src/node/mod.rs
@@ -144,6 +144,27 @@ where
         reply_rx.await.expect("receive reply_rx")
     }
 
+    /// Ingest an operation without publishing it.
+    pub async fn ingest(
+        &mut self,
+        header: &Header<Extensions>,
+        body: Option<&Body>,
+    ) -> Result<(), PublishError> {
+        let header_bytes = header.to_bytes();
+
+        self.stream_tx
+            .send(ToStreamController::Ingest {
+                header: header.to_owned(),
+                body: body.cloned(),
+                header_bytes,
+            })
+            .await
+            // @TODO: Handle error.
+            .unwrap();
+
+        Ok(())
+    }
+
     pub async fn publish_ephemeral(
         &mut self,
         topic: &T,
@@ -166,24 +187,19 @@ where
         header: &Header<Extensions>,
         body: Option<&Body>,
     ) -> Result<Hash, PublishError> {
-        let header_bytes = header.to_bytes();
         let operation_id = header.hash();
 
         let bytes = encode_gossip_message(header, body)?;
-        self.network_actor_tx
-            .send(ToNodeActor::Broadcast {
-                topic_id: topic.id(),
-                bytes,
-            })
+
+        self.ingest(&header, body)
             .await
             // @TODO: Handle error.
             .unwrap();
 
-        self.stream_tx
-            .send(ToStreamController::Ingest {
-                header: header.to_owned(),
-                body: body.cloned(),
-                header_bytes,
+        self.network_actor_tx
+            .send(ToNodeActor::Broadcast {
+                topic_id: topic.id(),
+                bytes,
             })
             .await
             // @TODO: Handle error.

--- a/src-tauri/src/rpc.rs
+++ b/src-tauri/src/rpc.rs
@@ -46,6 +46,26 @@ pub async fn ack(state: State<'_, Mutex<Context>>, operation_id: Hash) -> Result
     Ok(())
 }
 
+/// Add an author to a calendar.
+///
+/// This means that we will actively sync operations from this author for the specific calendar.
+#[tauri::command]
+pub async fn add_calendar_author(
+    state: State<'_, Mutex<Context>>,
+    public_key: PublicKey,
+    calendar_id: CalendarId,
+) -> Result<(), RpcError> {
+    debug!(
+        command.name = "add_calendar_author",
+        command.operation_id = public_key.to_hex(),
+        "RPC request received"
+    );
+
+    let state = state.lock().await;
+    state.topic_map.add_author(public_key, calendar_id).await;
+    Ok(())
+}
+
 /// Subscribe to a specific calendar by it's id.
 #[tauri::command]
 pub async fn subscribe_to_calendar(

--- a/src/lib/api/calendars.ts
+++ b/src/lib/api/calendars.ts
@@ -47,7 +47,7 @@ export const getActiveCalendar = liveQuery(async () => {
  */
 
 export async function create(
-  data: CalendarCreatedEvent["data"],
+  data: CalendarCreated["data"],
 ): Promise<Hash> {
   // Define the "calendar created" application event.
   //
@@ -56,7 +56,7 @@ export async function create(
   // hidden side-effects, if this could happen on the frontend with follow-up
   // IPC calls. This can be refactored when
   // https://github.com/toolkitties/toolkitty/issues/69 is implemented.
-  const payload: CalendarCreatedEvent = {
+  const payload: CalendarCreated = {
     type: "calendar_created",
     data,
   };
@@ -131,13 +131,13 @@ export async function process(message: ApplicationMessage) {
 
 async function onCalendarCreated(
   meta: StreamMessageMeta,
-  data: CalendarCreatedEvent["data"],
+  data: CalendarCreated["data"],
 ) {
   // Store calendar in database.
   await db.calendars.add({
     id: meta.calendarId,
     ownerId: meta.publicKey,
-    name: data.name,
+    name: data.fields.calendarName,
   });
 
   // Add the calendar creator the the list of authors who's data we want to 

--- a/src/lib/api/onboarding.ts
+++ b/src/lib/api/onboarding.ts
@@ -8,6 +8,8 @@ export async function joinWithInviteCode(
 
   await calendars.select(calendar.id);
   await calendars.subscribe(calendar.id);
+  // @TODO: add ourselves to the topic map for this calendar.
+  // await calendars.addCalendarAuthor(calendar.id, myPublicKey);
 
   // @TODO: At this point we've "joined" the calendar but we haven't received
   // the `CalendarCreated` event yet, which will ultimately update our database


### PR DESCRIPTION
* introduce `add_calendar_author` RPC method which can be called to add a new author to a calendar. The result of this being that our peer now actively syncs operations from this author for the specified calendar. 
* BONUS: don't subscribe to calendars within the `create_calendar` RPC method
* BONUS: split calendar topic into "inbox" and "data" (but don't do anything with it yet)