### PR TITLE
Set unique window title for peer

### DIFF
--- a/scripts/peer.sh
+++ b/scripts/peer.sh
@@ -19,6 +19,13 @@ tauri_json_config="{
   \"build\": {
     \"devUrl\": \"http://localhost:$TAURI_CLI_PORT\",
     \"beforeDevCommand\": \"VITE_DISABLE_HMR=1 npm run dev -- --port $TAURI_CLI_PORT\"
+  },
+  \"app\": {
+    \"windows\": [
+      {
+        \"title\": \"Toolkitty •ᴗ• peer $random_port\"
+      }
+    ]
   }
 }"
 


### PR DESCRIPTION
This PR adds a unique window title when launching new peers so its easier to distinguish them when running multiple instances of the app.