### PR TITLE
Upload, persist, sync and stream images

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -40,6 +40,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +333,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "bao-tree"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f7a89a8ee5889d2593ae422ce6e1bb03e48a0e8a16e4fa0882dfcbe7e182ef"
+dependencies = [
+ "bytes",
+ "futures-lite 2.6.0",
+ "genawaiter",
+ "iroh-blake3",
+ "iroh-io",
+ "positioned-io",
+ "range-collections",
+ "self_cell",
+ "smallvec",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,6 +378,12 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "binary-merge"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597bb81c80a54b6a4381b23faba8d7774b144c94cbd1d6fe3f1329bd776554ab"
 
 [[package]]
 name = "bitflags"
@@ -658,8 +693,10 @@ checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -1906,6 +1943,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "genawaiter"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0"
+dependencies = [
+ "futures-core",
+ "genawaiter-macro",
+ "genawaiter-proc-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "genawaiter-macro"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc"
+
+[[package]]
+name = "genawaiter-proc-macro"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784f84eebc366e15251c4a8c3acee82a6a6f427949776ecb88377362a9621738"
+dependencies = [
+ "proc-macro-error 0.4.12",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "generator"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2047,7 +2115,7 @@ checksum = "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-crate 2.0.0",
- "proc-macro-error",
+ "proc-macro-error 1.0.4",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -2147,7 +2215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff3c5b21f14f0736fed6dcfc0bfb4225ebf5725f3c0209edeec181e4d73e9d"
 dependencies = [
  "proc-macro-crate 1.3.1",
- "proc-macro-error",
+ "proc-macro-error 1.0.4",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -2188,7 +2256,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -2196,6 +2264,9 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash 0.8.11",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2209,6 +2280,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2219,6 +2299,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -2710,6 +2796,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inplace-vec-builder"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf64c2edc8226891a71f127587a2861b132d2b942310843814d5001d99a1d307"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2831,6 +2926,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "iroh-blobs"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a78917ffda5c440e23f1dc5680cb506cbdb2bd9f919fee0720a792e26321dff0"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "bao-tree",
+ "bytes",
+ "chrono",
+ "data-encoding",
+ "derive_more 1.0.0",
+ "futures-buffered",
+ "futures-lite 2.6.0",
+ "genawaiter",
+ "hashlink",
+ "hex",
+ "iroh",
+ "iroh-base",
+ "iroh-blake3",
+ "iroh-io",
+ "iroh-metrics",
+ "iroh-quinn",
+ "num_cpus",
+ "oneshot",
+ "parking_lot",
+ "postcard",
+ "rand 0.8.5",
+ "range-collections",
+ "redb",
+ "reflink-copy",
+ "self_cell",
+ "serde",
+ "serde-error",
+ "smallvec",
+ "tempfile",
+ "thiserror 2.0.11",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
 name = "iroh-gossip"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2857,6 +2996,19 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "iroh-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e302c5ad649c6a7aa9ae8468e1c4dc2469321af0c6de7341c1be1bdaab434b"
+dependencies = [
+ "bytes",
+ "futures-lite 2.6.0",
+ "pin-project",
+ "smallvec",
+ "tokio",
 ]
 
 [[package]]
@@ -3283,6 +3435,26 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "mainline"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b751ffb57303217bcae8f490eee6044a5b40eadf6ca05ff476cad37e7b7970d"
+dependencies = [
+ "bytes",
+ "crc",
+ "ed25519-dalek",
+ "flume",
+ "lru",
+ "rand 0.8.5",
+ "serde",
+ "serde_bencode",
+ "serde_bytes",
+ "sha1_smol",
+ "thiserror 1.0.69",
+ "tracing",
+]
 
 [[package]]
 name = "malloc_buf"
@@ -3741,6 +3913,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3755,7 +3937,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -4023,6 +4205,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "oneshot"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce411919553d3f9fa53a0880544cda985a112117a0444d5ff1e870a893d6ea"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4077,6 +4265,30 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "p2panda-blobs"
+version = "0.2.0"
+source = "git+https://github.com/p2panda/p2panda?rev=3ad402697feaf8287f779735f019fd9431320df0#3ad402697feaf8287f779735f019fd9431320df0"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "bytes",
+ "futures-buffered",
+ "futures-lite 2.6.0",
+ "futures-util",
+ "iroh",
+ "iroh-base",
+ "iroh-blobs",
+ "iroh-io",
+ "p2panda-core",
+ "p2panda-net",
+ "p2panda-sync",
+ "serde",
+ "serde-error",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "p2panda-core"
@@ -4481,11 +4693,13 @@ checksum = "92eff194c72f00f3076855b413ad2d940e3a6e307fa697e5c7733e738341aed4"
 dependencies = [
  "bytes",
  "document-features",
+ "dyn-clone",
  "ed25519-dalek",
  "flume",
  "futures",
  "js-sys",
  "lru",
+ "mainline",
  "self_cell",
  "simple-dns",
  "thiserror 2.0.11",
@@ -4628,6 +4842,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "positioned-io"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccabfeeb89c73adf4081f0dca7f8e28dbda90981a222ceea37f619e93ea6afe9"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "postcard"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4736,14 +4960,40 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
+dependencies = [
+ "proc-macro-error-attr 0.4.12",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
- "proc-macro-error-attr",
+ "proc-macro-error-attr 1.0.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "syn-mid",
  "version_check",
 ]
 
@@ -5014,6 +5264,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "range-collections"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "861706ea9c4aded7584c5cd1d241cec2ea7f5f50999f236c22b65409a1f1a0d0"
+dependencies = [
+ "binary-merge",
+ "inplace-vec-builder",
+ "ref-cast",
+ "smallvec",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "11.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5042,6 +5304,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redb"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0a72cd7140de9fc3e318823b883abf819c20d478ec89ce880466dc2ef263c6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5059,6 +5330,38 @@ dependencies = [
  "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf0a6f84d5f1d581da8b41b47ec8600871962f2a528115b542b362d4b744931"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "reflink-copy"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbd3533fd4222b8337470456ea84d80436b4c91c53db51c372461d5f7e6eb0b4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rustix",
+ "windows 0.59.0",
 ]
 
 [[package]]
@@ -5596,6 +5899,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bencode"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a70dfc7b7438b99896e7f8992363ab8e2c4ba26aa5ec675d32d1c3c2c33d413e"
+dependencies = [
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5754,6 +6067,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5863,6 +6182,9 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -6122,6 +6444,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn-mid"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea305d57546cc8cd04feb14b62ec84bf17f50e3f7b12560d7bfa9265f39d9ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6784,6 +7117,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.14.5",
  "pin-project-lite",
+ "slab",
  "tokio",
 ]
 
@@ -6876,6 +7210,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "futures-util",
+ "iroh-io",
+ "p2panda-blobs",
  "p2panda-core",
  "p2panda-discovery",
  "p2panda-net",
@@ -6955,6 +7291,16 @@ checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3937,7 +3937,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -7226,6 +7226,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-log",
  "tauri-plugin-shell",
+ "tempfile",
  "thiserror 2.0.11",
  "tokio",
  "tokio-stream",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7211,6 +7211,7 @@ dependencies = [
  "async-trait",
  "futures-util",
  "iroh-io",
+ "mime",
  "p2panda-blobs",
  "p2panda-core",
  "p2panda-discovery",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -120,6 +120,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "ashpd"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c39d707614dbcc6bed00015539f488d8e3fe3e66ed60961efc0c90f4b380b3"
+dependencies = [
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.8.5",
+ "raw-window-handle",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
+]
+
+[[package]]
 name = "asn1-rs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +177,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1196,6 +1229,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "dlopen2"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,6 +1279,12 @@ checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -1342,6 +1390,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,6 +1414,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba2f4b465f5318854c6f8dd686ede6c0a9dc67d4b1ac241cf0eb51521a309147"
 dependencies = [
  "enumflags2_derive",
+ "serde",
 ]
 
 [[package]]
@@ -1413,6 +1468,16 @@ name = "erased_set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a02a5d186d7bf1cb21f1f95e1a9cfa5c1f2dcd803a47aad454423ceec13525c5"
+
+[[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "event-listener"
@@ -1899,6 +1964,18 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3130,6 +3207,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
 name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3567,6 +3650,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.8.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3792,6 +3888,7 @@ checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
  "bitflags 2.8.0",
  "block2",
+ "dispatch",
  "libc",
  "objc2",
 ]
@@ -3954,6 +4051,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "os_pipe"
@@ -4414,7 +4521,7 @@ checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.7.1",
- "quick-xml",
+ "quick-xml 0.32.0",
  "serde",
  "time",
 ]
@@ -4740,6 +4847,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5060,6 +5176,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a24763657bff09769a8ccf12c8b8a50416fb035fe199263b4c5071e4e3f006f"
+dependencies = [
+ "ashpd",
+ "block2",
+ "core-foundation 0.10.0",
+ "core-foundation-sys",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5183,6 +5324,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.8.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5803,6 +5957,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "string_cache"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6216,6 +6376,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-dialog"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b59fd750551b1066744ab956a1cd6b1ea3e1b3763b0b9153ac27a044d596426"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.11",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a1edf18000f02903a7c2e5997fb89aca455ecbc0acc15c6535afbb883be223"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "percent-encoding",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.11",
+ "toml 0.8.19",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "tauri-plugin-log"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6348,6 +6549,20 @@ checksum = "5993dc129e544393574288923d1ec447c857f3f644187f4fbf7d9a875fbfc4fb"
 dependencies = [
  "embed-resource",
  "toml 0.7.8",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+dependencies = [
+ "cfg-if",
+ "fastrand 2.3.0",
+ "getrandom 0.3.1",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6489,6 +6704,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.52.0",
 ]
 
@@ -6670,6 +6886,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-log",
  "tauri-plugin-shell",
  "thiserror 2.0.11",
@@ -6862,6 +7079,17 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uds_windows"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "winapi",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -7102,6 +7330,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7183,6 +7420,66 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7208998eaa3870dad37ec8836979581506e0c5c64c20c9e79e9d2a10d6f47bf"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2120de3d33638aaef5b9f4472bff75f07c56379cf76ea320bd3a3d65ecaf73f"
+dependencies = [
+ "bitflags 2.8.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0781cf46869b37e36928f7b432273c0995aa8aed9552c556fb18754420541efc"
+dependencies = [
+ "bitflags 2.8.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "896fdafd5d28145fce7958917d69f2fd44469b1d4e861cb5961bcbeebc6d1484"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.37.2",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbcebb399c77d5aa9fa5db874806ee7b4eba4e73650948e8f93963f128896615"
+dependencies = [
+ "dlib",
+ "log",
+ "pkg-config",
 ]
 
 [[package]]
@@ -7807,6 +8104,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7824,6 +8130,15 @@ checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -7944,6 +8259,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "xml-rs"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7996,6 +8321,63 @@ name = "z32"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb37266251c28b03d08162174a91c3a092e3bd4f476f8205ee1c507b78b7bdc"
+
+[[package]]
+name = "zbus"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c333f648ea1b647bc95dc1d34807c8e25ed7a6feff3394034dc4776054b236"
+dependencies = [
+ "async-broadcast",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite 2.6.0",
+ "hex",
+ "nix 0.29.0",
+ "ordered-stream",
+ "serde",
+ "serde_repr",
+ "static_assertions",
+ "tokio",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.59.0",
+ "winnow 0.7.3",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f325ad10eb0d0a3eb060203494c3b7ec3162a01a59db75d2deee100339709fc0"
+dependencies = [
+ "proc-macro-crate 3.2.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "winnow 0.7.3",
+ "zvariant",
+]
 
 [[package]]
 name = "zerocopy"
@@ -8065,4 +8447,47 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2df9ee044893fcffbdc25de30546edef3e32341466811ca18421e3cd6c5a3ac"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "url",
+ "winnow 0.7.3",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74170caa85b8b84cc4935f2d56a57c7a15ea6185ccdd7eadb57e6edd90f94b2f"
+dependencies = [
+ "proc-macro-crate 3.2.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16edfee43e5d7b553b77872d99bc36afdda75c223ca7ad5e3fbecd82ca5fc34"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "static_assertions",
+ "syn 2.0.96",
+ "winnow 0.7.3",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,18 +18,15 @@ anyhow = "1.0.95"
 async-trait = "0.1.85"
 futures-util = "0.3.31"
 p2panda-core = { git = "https://github.com/p2panda/p2panda", rev = "3ad402697feaf8287f779735f019fd9431320df0" }
-p2panda-discovery = { git = "https://github.com/p2panda/p2panda", rev = "3ad402697feaf8287f779735f019fd9431320df0", features = [
-    "mdns",
-] }
+p2panda-discovery = { git = "https://github.com/p2panda/p2panda", rev = "3ad402697feaf8287f779735f019fd9431320df0", features = ["mdns"] }
 p2panda-net = { git = "https://github.com/p2panda/p2panda", rev = "3ad402697feaf8287f779735f019fd9431320df0" }
 p2panda-store = { git = "https://github.com/p2panda/p2panda", rev = "3ad402697feaf8287f779735f019fd9431320df0" }
 p2panda-stream = { git = "https://github.com/p2panda/p2panda", rev = "3ad402697feaf8287f779735f019fd9431320df0" }
-p2panda-sync = { git = "https://github.com/p2panda/p2panda", rev = "3ad402697feaf8287f779735f019fd9431320df0", features = [
-    "log-sync",
-] }
+p2panda-sync = { git = "https://github.com/p2panda/p2panda", rev = "3ad402697feaf8287f779735f019fd9431320df0", features = ["log-sync"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2", features = [] }
+tauri-plugin-dialog = "2"
 tauri-plugin-log = "2"
 tauri-plugin-shell = "2"
 thiserror = "2.0.9"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,6 +17,8 @@ tauri-build = { version = "2", features = [] }
 anyhow = "1.0.95"
 async-trait = "0.1.85"
 futures-util = "0.3.31"
+iroh-io = "0.6.1"
+p2panda-blobs = { git = "https://github.com/p2panda/p2panda", rev = "3ad402697feaf8287f779735f019fd9431320df0" }
 p2panda-core = { git = "https://github.com/p2panda/p2panda", rev = "3ad402697feaf8287f779735f019fd9431320df0" }
 p2panda-discovery = { git = "https://github.com/p2panda/p2panda", rev = "3ad402697feaf8287f779735f019fd9431320df0", features = ["mdns"] }
 p2panda-net = { git = "https://github.com/p2panda/p2panda", rev = "3ad402697feaf8287f779735f019fd9431320df0" }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ anyhow = "1.0.95"
 async-trait = "0.1.85"
 futures-util = "0.3.31"
 iroh-io = "0.6.1"
+mime = "0.3.17"
 p2panda-blobs = { git = "https://github.com/p2panda/p2panda", rev = "3ad402697feaf8287f779735f019fd9431320df0" }
 p2panda-core = { git = "https://github.com/p2panda/p2panda", rev = "3ad402697feaf8287f779735f019fd9431320df0" }
 p2panda-discovery = { git = "https://github.com/p2panda/p2panda", rev = "3ad402697feaf8287f779735f019fd9431320df0", features = ["mdns"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,3 +38,6 @@ tokio-stream = { version = "0.1.17", features = ["sync"] }
 tokio-util = "0.7.13"
 tokio-utils = "0.1.2"
 tracing = "0.1.41"
+
+[dev-dependencies]
+tempfile = "3.17.1"

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -134,8 +134,8 @@ impl Service {
     /// Spawn the service task.
     #[cfg(test)]
     pub async fn run() -> Arc<RwLock<Context>> {
-        let temp_blobs_root_dir = std::env::temp_dir();
-        let mut app = Self::build(temp_blobs_root_dir)
+        let temp_blobs_root_dir = tempfile::tempdir().expect("temp dir");
+        let mut app = Self::build(temp_blobs_root_dir.into_path())
             .await
             .expect("build stream");
         let context = app.context.clone();

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -336,7 +336,7 @@ impl Rpc {
 
     pub async fn publish_ephemeral(&self, topic: &Topic, payload: &[u8]) -> Result<(), RpcError> {
         let mut context = self.context.write().await;
-        context.node.publish_ephemeral(&topic, &payload).await?;
+        context.node.publish_ephemeral(topic, payload).await?;
         Ok(())
     }
 

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -197,7 +197,7 @@ impl Service {
 }
 
 pub struct Rpc {
-    context: Arc<RwLock<Context>>,
+    pub(crate) context: Arc<RwLock<Context>>,
 }
 
 impl Rpc {

--- a/src-tauri/src/blobs.rs
+++ b/src-tauri/src/blobs.rs
@@ -1,0 +1,145 @@
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{bail, Result};
+use iroh_io::AsyncSliceReaderExt;
+use p2panda_core::Hash;
+use tauri::http::{header, Request, Response, StatusCode, Uri};
+use tauri::{Manager, Runtime, UriSchemeContext, UriSchemeResponder};
+use tokio::sync::RwLock;
+use tokio::task::LocalSet;
+use tokio::time::timeout;
+
+use crate::app::{Context, Rpc};
+
+/// Time limit we give for finding another peer and downloading the blob from them before we give
+/// up and return a "Not found" (404) error.
+const SYNC_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Handler for the custom blobstore:// URI scheme protocol which will be registered in the Tauri
+/// WebView.
+///
+/// This allows the frontend to request a file addressed with it's hash. First we check if the file
+/// exists in our local blob store, if not, we'll request to download the file from other peers.
+/// This might take a while as no peer with that file might be online, the user will receive a
+/// timeout after a while which can be interpreted as a "not found" 404 failure.
+///
+/// To make this work in Tauri we need to allow this protocol in the CSP config, for example via:
+///
+/// ```json
+/// "csp": {
+///   "img-src": "'self' data: blobstore:"
+/// }
+/// ```
+pub fn blobstore_protocol<R: Runtime>(
+    ctx: UriSchemeContext<'_, R>,
+    request: Request<Vec<u8>>,
+    responder: UriSchemeResponder,
+) {
+    let context = { ctx.app_handle().state::<Rpc>().context.clone() };
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    std::thread::spawn(move || {
+        let local = LocalSet::new();
+
+        local.spawn_local(async move {
+            let response = match parse_blob_hash(request.uri()) {
+                Ok(blob_hash) => handle_request(context, blob_hash, true).await,
+                Err(err) => error(StatusCode::BAD_REQUEST, err.to_string()),
+            };
+
+            let response = response.unwrap_or_else(|err| {
+                error(StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).unwrap()
+            });
+
+            responder.respond(response);
+        });
+
+        // This will return once all senders are dropped and all
+        // spawned tasks have returned.
+        rt.block_on(local);
+    });
+}
+
+/// Extracts the blob's hash from the request URI. The hash is encoded as a 64 hexadecimal
+/// character string.
+///
+/// blobstore://<hash>
+///               |
+///           URI "host"
+fn parse_blob_hash(uri: &Uri) -> Result<Hash> {
+    let Some(hash_str) = uri.host() else {
+        bail!("blob hash missing");
+    };
+
+    let Ok(hash) = Hash::from_str(&hash_str) else {
+        bail!("invalid hexadecimal blob hash string");
+    };
+
+    Ok(hash)
+}
+
+async fn handle_request(
+    context: Arc<RwLock<Context>>,
+    blob_hash: Hash,
+    first_attempt: bool,
+) -> ResponseResult {
+    let context_read = context.read().await;
+    let result = context_read.node.read_file(blob_hash).await;
+    match result {
+        // We have the blob locally on our machine, forward it to the frontend.
+        Ok(Some(mut file)) => match file.read_to_end().await {
+            Ok(file_bytes) => Response::builder()
+                .status(StatusCode::OK)
+                .body(file_bytes.to_vec()),
+            Err(err) => error(StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
+        },
+        // We don't have the blob, try to sync it from another peer first.
+        Ok(None) => {
+            if first_attempt {
+                drop(context_read);
+                try_lazy_sync(context, blob_hash).await
+            } else {
+                error(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.to_string())
+            }
+        }
+        Err(err) => error(StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
+    }
+}
+
+async fn try_lazy_sync(context: Arc<RwLock<Context>>, blob_hash: Hash) -> ResponseResult {
+    let context_read = context.read().await;
+    let result = timeout(SYNC_TIMEOUT, context_read.node.sync_remote_file(blob_hash)).await;
+    match result {
+        // Sync succeeded, we have the file! Continue handling request and respond with our now
+        // local version of the blob.
+        Ok(Ok(_)) => {
+            drop(context_read);
+            Box::pin(handle_request(context, blob_hash, false)).await
+        }
+        // Sync thrown an exception.
+        Ok(Err(err)) => error(StatusCode::NOT_FOUND, err.to_string()),
+        // Timeout has passed threshold.
+        Err(elapsed) => error(
+            StatusCode::NOT_FOUND,
+            format!(
+                "could not find a peer to sync blob within time limit: {}",
+                elapsed.to_string()
+            ),
+        ),
+    }
+}
+
+fn error(status_code: StatusCode, message: String) -> ResponseResult {
+    Response::builder()
+        .status(status_code)
+        .header(header::CONTENT_TYPE, mime::TEXT_PLAIN.essence_str())
+        .body(message.as_bytes().to_vec())
+}
+
+type ResponseResult = Result<Response<Vec<u8>>, tauri::http::Error>;

--- a/src-tauri/src/blobs.rs
+++ b/src-tauri/src/blobs.rs
@@ -89,7 +89,7 @@ fn parse_blob_hash(uri: &Uri) -> Result<Hash> {
     };
 
     if let Some(path) = uri.path_and_query() {
-        if path.to_string() != "/" {
+        if *path != "/" {
             bail!("suspicious suffix after blob hash");
         }
     }

--- a/src-tauri/src/blobs.rs
+++ b/src-tauri/src/blobs.rs
@@ -77,7 +77,7 @@ fn parse_blob_hash(uri: &Uri) -> Result<Hash> {
         bail!("blob hash missing");
     };
 
-    let Ok(hash) = Hash::from_str(&hash_str) else {
+    let Ok(hash) = Hash::from_str(hash_str) else {
         bail!("invalid hexadecimal blob hash string");
     };
 
@@ -129,7 +129,7 @@ async fn try_lazy_sync(context: Arc<RwLock<Context>>, blob_hash: Hash) -> Respon
             StatusCode::NOT_FOUND,
             format!(
                 "could not find a peer to sync blob within time limit: {}",
-                elapsed.to_string()
+                elapsed
             ),
         ),
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,7 +8,7 @@ use tauri::Builder;
 
 use crate::rpc::{
     ack, add_topic_log, init, public_key, publish, publish_ephemeral, replay, subscribe,
-    subscribe_ephemeral,
+    subscribe_ephemeral, upload_file,
 };
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -43,6 +43,7 @@ pub fn run() {
             replay,
             subscribe,
             subscribe_ephemeral,
+            upload_file,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,7 +18,7 @@ pub fn run() {
         .filter(|metadata| metadata.target().starts_with("toolkitty_lib"))
         .build();
 
-    let mut builder = Builder::default();
+    let builder = Builder::default();
 
     #[cfg(not(test))]
     {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod app;
+mod blobs;
 mod messages;
 mod node;
 mod rpc;
@@ -29,7 +30,7 @@ pub fn run() {
     };
 
     builder
-        // .register_asynchronous_uri_scheme_protocol(uri_scheme, protocol)
+        .register_asynchronous_uri_scheme_protocol("blobstore", blobs::blobstore_protocol)
         .plugin(logger)
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,8 +29,10 @@ pub fn run() {
     };
 
     builder
+        // .register_asynchronous_uri_scheme_protocol(uri_scheme, protocol)
         .plugin(logger)
         .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_dialog::init())
         .invoke_handler(tauri::generate_handler![
             init,
             ack,
@@ -40,7 +42,7 @@ pub fn run() {
             publish_ephemeral,
             replay,
             subscribe,
-            subscribe_ephemeral
+            subscribe_ephemeral,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,7 +18,8 @@ pub fn run() {
         .filter(|metadata| metadata.target().starts_with("toolkitty_lib"))
         .build();
 
-    let builder = Builder::default();
+    #[allow(unused_mut)]
+    let mut builder = Builder::default();
 
     #[cfg(not(test))]
     {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,7 +31,10 @@ pub fn run() {
     };
 
     builder
-        .register_asynchronous_uri_scheme_protocol("blobstore", blobs::blobstore_protocol)
+        .register_asynchronous_uri_scheme_protocol(
+            blobs::BLOBSTORE_URI_SCHEME,
+            blobs::blobstore_protocol,
+        )
         .plugin(logger)
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())

--- a/src-tauri/src/node/mod.rs
+++ b/src-tauri/src/node/mod.rs
@@ -266,7 +266,7 @@ where
             .blobs
             .get(hash)
             .await
-            .map_err(|err| BlobError::InvalidFileHandle(err))?;
+            .map_err(BlobError::InvalidFileHandle)?;
         match file_handle {
             Some(handle) => {
                 if !handle.is_complete() {

--- a/src-tauri/src/rpc.rs
+++ b/src-tauri/src/rpc.rs
@@ -1,5 +1,7 @@
 use p2panda_core::{Hash, PublicKey};
+use tauri::AppHandle;
 use tauri::{ipc::Channel, State};
+use tauri_plugin_dialog::DialogExt;
 use tokio::sync::broadcast;
 use tracing::debug;
 
@@ -132,8 +134,20 @@ pub async fn publish_ephemeral(
     payload: serde_json::Value,
 ) -> Result<(), RpcError> {
     debug!(command.name = "publish_ephemeral", "RPC request received");
-
     let payload = serde_json::to_vec(&payload)?;
     rpc.publish_ephemeral(&topic, &payload).await?;
     Ok(())
+}
+
+#[tauri::command]
+pub async fn upload_file(rpc: State<'_, Rpc>, app: AppHandle) -> Result<Option<Hash>, RpcError> {
+    debug!(command.name = "upload_file", "RPC request received");
+    match app.dialog().file().blocking_pick_file() {
+        Some(file_path) => {
+            let file_path = file_path.into_path().expect("parseable file path");
+            let file_hash = rpc.upload_file(file_path).await?;
+            Ok(Some(file_hash))
+        }
+        None => Ok(None),
+    }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,15 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": {
+        "default-src": "none",
+        "connect-src": "'self' ipc: http://ipc.localhost",
+        "style-src": "'self' 'unsafe-inline'",
+        "font-src": "'self'",
+        "script-src": "'self'",
+        "img-src": "'self' data: blobstore:",
+        "media-src": "'self' blobstore:"
+      }
     }
   },
   "bundle": {

--- a/src/lib/api/blobs.ts
+++ b/src/lib/api/blobs.ts
@@ -1,0 +1,22 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * Invokes a file selector in the backend and imports the selected file into
+ * local blob store.
+ *
+ * If a file was selected by the user, it will be processed by the backend and
+ * the resulting hash will be returned here. This "blob hash" is now the unique
+ * identifier of the uploaded file and it can be used to display images with
+ * the `blobstore://` URI scheme, for example like that:
+ *
+ * ```
+ * <img src="blobstore://<hash>" />
+ * ```
+ *
+ * Make sure to check the Tauri CSP settings if you intend to use the blobstore
+ * scheme in other contexts as well.
+ */
+export async function uploadFile(): Promise<Hash> {
+  const blobHash = await invoke("upload_file");
+  return blobHash as Hash;
+}

--- a/src/lib/api/blobs.ts
+++ b/src/lib/api/blobs.ts
@@ -1,11 +1,11 @@
 import { invoke } from "@tauri-apps/api/core";
 
 /**
- * Invokes a file selector in the backend and imports the selected file into
- * local blob store.
+ * Opens a file selector dialog in the backend and imports the selected file
+ * into our local blob store on the device's filesystem.
  *
  * If a file was selected by the user, it will be processed by the backend and
- * the resulting hash will be returned here. This "blob hash" is now the unique
+ * the resulting hash returned here. This "blob hash" is now the unique
  * identifier of the uploaded file and it can be used to display images with
  * the `blobstore://` URI scheme, for example like that:
  *


### PR DESCRIPTION
We can now invoke a `upload_file` RPC method in the frontend. This will trigger a file selection dialog.

If a file was selected by the user, it will be processed by the backend (bao encoding, stored in filesystem) and the resulting hash will be returned. This "blob hash" is now the unique identifier of the uploaded file and it can be used to display images with the `blobstore://` URI scheme, for example like that:

```html
<img src="blobstore://<hash>" />
```

For the frontend this URI behaves like a regular HTTP request, with a bit of magic.

When we request a file via the `blobstore` URI protocol, we check if the file exists in our local blob store, if not, we'll request to download the file from other peers. This might take a while. In case no peer was available we receive a timeout (currently five seconds) which is then returned as a "not found" 404 HTTP response to the frontend.

Blobs are persisted on filesystem inside the application's XDG "data" directory.

**Open Questions**

1. This logic currently implies a "lazy" approach, where blobs only get requested from other peers if they are actively used in the frontend (for example by opening a view where an image is embedded). With this system we will not be able to show the images if it wasn't requested earlier on and that peer is offline. Another approach would be to always "eagerly" download _all_ known blobs while that peer is online to make sure we have them around later.
2. The whole logic is agnostic to file types, we can also imagine uploading PDFs here and whatnot. Do we want that? We can offer at least a filter for the file selector which can be configured from the frontend when calling `upload_file`?
3. We should probably resize / compress images when that file type was used.
4. Store "hygiene" will be important at one point: when do we delete unused / old files?

Closes: #67 