### PR TITLE
Toasts and Header component style fixes

### DIFF
--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -9,7 +9,7 @@
   const activeCalendarName = calendars.getActiveCalendar;
 </script>
 
-<div class="fixed top-0 left-0 p-2 right-2 w-full bg-white space-y-1.5">
+<div class="sticky top-0 left-0 p-2 right-2 w-full bg-white space-y-1.5">
   <div class="flex justify-between border border-black rounded-full px-2">
     <span>{$activeCalendarName}</span>
     <span>{title}</span>

--- a/src/lib/components/Toasts.svelte
+++ b/src/lib/components/Toasts.svelte
@@ -22,7 +22,7 @@
   }
 </script>
 
-<section class="absolute top-8 right-0 p-3 w-full">
+<section class="fixed top-8 right-0 p-3 w-full z-30">
   <ol tabIndex={-1} class="space-y-2">
     {#each toast.toasts as t}
       <li


### PR DESCRIPTION
This PR fixes following style problems with Toasts and Header components:

- Make header `position: sticky` so that it doesn't sit on top of page content.
- Increase toasts container `z-index` so it sits on top of header.
- Make toasts `position: fixed` so they are visible when scrolling a page.