### PR TITLE
General frontend API improvements

### DIFF
--- a/src/lib/api/calendars.ts
+++ b/src/lib/api/calendars.ts
@@ -10,21 +10,18 @@ import { TopicFactory } from "./topics";
  * Queries
  */
 
-export async function findMany(): Promise<Calendar[]> {
-  return await db.calendars.toArray();
+export function findMany(): Promise<Calendar[]> {
+  return db.calendars.toArray();
 }
 
-export async function findOne(id: Hash): Promise<Calendar | undefined> {
-  return await db.calendars.get({ id });
+export function findOne(id: Hash): Promise<Calendar | undefined> {
+  return db.calendars.get({ id });
 }
 
-export async function findByInviteCode(
-  code: string,
-): Promise<undefined | Calendar> {
-  const calendars = await findMany();
-  return calendars.find((calendar) => {
-    return inviteCode(calendar) === code;
-  });
+export function findByInviteCode(code: string): Promise<undefined | Calendar> {
+  return db.calendars
+    .filter((calendar) => inviteCode(calendar) === code)
+    .first();
 }
 
 export function inviteCode(calendar: Calendar): string {
@@ -34,9 +31,8 @@ export function inviteCode(calendar: Calendar): string {
 /*
  * Returns the id of the currently active calendar
  */
-export async function getActiveCalendarId() {
-  const activeCalendar = await db.settings.get("activeCalendar");
-  return activeCalendar?.value;
+export function getActiveCalendarId(): Promise<string | undefined> {
+  return db.settings.get("activeCalendar").then((activeCalendar) => activeCalendar?.value);
 }
 
 /*

--- a/src/lib/api/calendars.ts
+++ b/src/lib/api/calendars.ts
@@ -15,8 +15,7 @@ export async function findMany(): Promise<Calendar[]> {
 }
 
 export async function findOne(id: Hash): Promise<Calendar | undefined> {
-  let calendars = await db.calendars.toArray();
-  return calendars.find((calendar) => calendar.id == id);
+  return await db.calendars.get({ id });
 }
 
 export async function findByInviteCode(

--- a/src/lib/api/data.ts
+++ b/src/lib/api/data.ts
@@ -16,7 +16,7 @@ export async function seedData() {
 
   await setActiveCalendar(calendarId);
 
-  const spaceOneId = await spaces.create({
+  const spaceOneId = await spaces.create(calendarId, {
     type: "physical",
     name: "1",
     location: "123 Street Street",
@@ -42,7 +42,7 @@ export async function seedData() {
     multiBookable: false,
   });
 
-  const spaceTwoId = await spaces.create({
+  const spaceTwoId = await spaces.create(calendarId, {
     type: "physical",
     name: "Recording Studio",
     location: "34 Road Avenue",
@@ -69,7 +69,7 @@ export async function seedData() {
     multiBookable: false,
   });
 
-  const resourceOneId = await resources.create({
+  const resourceOneId = await resources.create(calendarId, {
     name: "Projector",
     description: "Epson CO-FH01 Full HD Projector",
     contact: "Signal @beamer",
@@ -92,7 +92,7 @@ export async function seedData() {
     multiBookable: false,
   });
 
-  const resourceTwoId = await resources.create({
+  const resourceTwoId = await resources.create(calendarId, {
     name: "XLR Cables",
     description: "as above. Call me to confirm pick up",
     contact: "",
@@ -111,7 +111,7 @@ export async function seedData() {
     multiBookable: false,
   });
 
-  await events.create({
+  await events.create(calendarId, {
     name: "Kitty Fest 25",
     description: "A grand music festival with various artists.",
     startDate: new Date("2025-01-06T14:00:00Z"),
@@ -122,7 +122,7 @@ export async function seedData() {
     links: [],
   });
 
-  await events.create({
+  await events.create(calendarId, {
     name: "Kitty Fest 25",
     description: "A grand music festival with various artists.",
     startDate: new Date("2025-01-06T14:00:00Z"),
@@ -133,7 +133,7 @@ export async function seedData() {
     links: [],
   });
 
-  await events.create({
+  await events.create(calendarId, {
     name: "Art Exhibition",
     description: "An exhibition showcasing modern art.",
     startDate: new Date("2025-02-10T10:00:00.000Z"),

--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -11,25 +11,25 @@ import { events, publish } from ".";
 /**
  * Get events that are associated with the passed calendar
  */
-export async function findMany(calendarId: Hash): Promise<CalendarEvent[]> {
-  return await db.events.where({ calendarId }).toArray();
+export function findMany(calendarId: Hash): Promise<CalendarEvent[]> {
+  return db.events.where({ calendarId }).toArray();
 }
 
 /**
  * Get all calendar events owned by the passed public key.
  */
-export async function findByOwner(
+export function findByOwner(
   calendarId: Hash,
   ownerId: PublicKey,
 ): Promise<CalendarEvent[]> {
-  return await db.events.where({ ownerId, calendarId }).toArray();
+  return db.events.where({ ownerId, calendarId }).toArray();
 }
 
 /**
  * Get one event via its id
  */
-export async function findById(id: Hash): Promise<CalendarEvent | undefined> {
-  return await db.events.get({ id });
+export function findById(id: Hash): Promise<CalendarEvent | undefined> {
+  return db.events.get({ id });
 }
 
 /**

--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -22,23 +22,14 @@ export async function findMany(): Promise<CalendarEvent[]> {
  */
 export async function findMine(): Promise<CalendarEvent[]> {
   let myPublicKey = await publicKey();
-  let events = (await db.events.toArray()).filter(
-    (resource) => resource.ownerId == myPublicKey,
-  );
-  return events;
+  return await db.events.where({ ownerId: myPublicKey }).toArray();
 }
 
 /**
  * Get one event via its id
  */
 export async function findById(id: Hash): Promise<CalendarEvent | undefined> {
-  let events = (await db.events.toArray()).filter((events) => events.id == id);
-
-  if (events.length == 0) {
-    return;
-  }
-
-  return events[0];
+  return await db.events.get({ id });
 }
 
 /**

--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -9,14 +9,14 @@ import { events, publish } from ".";
  */
 
 /**
- * Get events that are associated with the currently active calendar
+ * Get events that are associated with the passed calendar
  */
 export async function findMany(calendarId: Hash): Promise<CalendarEvent[]> {
   return await db.events.where({ calendarId }).toArray();
 }
 
 /**
- * Get all events that are owned by a certain public key.
+ * Get all calendar events owned by the passed public key.
  */
 export async function findByOwner(
   calendarId: Hash,
@@ -36,6 +36,9 @@ export async function findById(id: Hash): Promise<CalendarEvent | undefined> {
  * Commands
  */
 
+/**
+ * Create a calendar event.
+ */
 export async function create(calendarId: Hash, fields: EventFields) {
   let eventCreated: EventCreated = {
     type: "event_created",
@@ -53,6 +56,9 @@ export async function create(calendarId: Hash, fields: EventFields) {
   return operationId;
 }
 
+/**
+ * Update a calendar event.
+ */
 export async function update(eventId: Hash, fields: EventFields) {
   const event = await events.findById(eventId);
   let eventUpdated: EventUpdated = {
@@ -72,6 +78,9 @@ export async function update(eventId: Hash, fields: EventFields) {
   return operationId;
 }
 
+/**
+ * Delete a calendar event.
+ */
 async function deleteEvent(eventId: Hash) {
   const event = await events.findById(eventId);
   let eventDeleted: EventDeleted = {
@@ -92,6 +101,10 @@ async function deleteEvent(eventId: Hash) {
 
 //TODO: Move to class so we don't have to export as an alias
 export { deleteEvent as delete };
+
+/**
+ * Processors
+ */
 
 export async function process(message: ApplicationMessage) {
   const meta = message.meta;

--- a/src/lib/api/resources.ts
+++ b/src/lib/api/resources.ts
@@ -8,14 +8,14 @@ import { promiseResult } from "$lib/promiseMap";
  */
 
 /**
- * Get resources that are associated with the currently active calendar
+ * Get resources that are associated with the passed calendar
  */
 export async function findMany(calendarId: Hash): Promise<Resource[]> {
   return await db.resources.where({ calendarId }).toArray();
 }
 
 /**
- * Get all resources that are owned by a certain public key.
+ * Get all calendar resources that are owned by the passed public key.
  */
 export async function findByOwner(
   calendarId: Hash,
@@ -25,7 +25,7 @@ export async function findByOwner(
 }
 
 /**
- * Get one event by its ID
+ * Get one event by its ID.
  */
 export async function findById(id: Hash): Promise<Resource | undefined> {
   return await db.resources.get({ id: id });
@@ -35,6 +35,9 @@ export async function findById(id: Hash): Promise<Resource | undefined> {
  * Commands
  */
 
+/**
+ * Create a calendar resource.
+ */
 export async function create(calendarId: Hash, fields: ResourceFields): Promise<Hash> {
   let resourceCreated: ResourceCreated = {
     type: "resource_created",
@@ -52,6 +55,9 @@ export async function create(calendarId: Hash, fields: ResourceFields): Promise<
   return operationId;
 }
 
+/**
+ * Update a calendar resource.
+ */
 export async function update(
   resourceId: Hash,
   fields: ResourceFields,
@@ -74,6 +80,9 @@ export async function update(
   return operationId;
 }
 
+/**
+ * Delete a calendar resource.
+ */
 export async function deleteResource(resourceId: Hash): Promise<Hash> {
   let resource = await resources.findById(resourceId);
   let resourceDeleted: ResourceDeleted = {

--- a/src/lib/api/resources.ts
+++ b/src/lib/api/resources.ts
@@ -12,8 +12,7 @@ import { promiseResult } from "$lib/promiseMap";
  * Get resources that are associated with the currently active calendar
  */
 export async function findMany(): Promise<Resource[]> {
-  let resources = await db.resources.toArray();
-  return resources;
+  return await db.resources.toArray();
 }
 
 /**
@@ -21,25 +20,14 @@ export async function findMany(): Promise<Resource[]> {
  */
 export async function findMine(): Promise<Resource[]> {
   let myPublicKey = await publicKey();
-  let resources = (await db.resources.toArray()).filter(
-    (resource) => resource.ownerId == myPublicKey,
-  );
-  return resources;
+  return await db.resources.where({ ownerId: myPublicKey }).toArray();
 }
 
 /**
  * Get one event by its ID
  */
 export async function findById(id: Hash): Promise<Resource | undefined> {
-  let resource = (await db.resources.toArray()).filter(
-    (resource) => resource.id == id,
-  );
-
-  if (resource.length == 0) {
-    return;
-  }
-
-  return resource[0];
+  return await db.resources.get({id: id})
 }
 
 /**

--- a/src/lib/api/resources.ts
+++ b/src/lib/api/resources.ts
@@ -10,25 +10,25 @@ import { promiseResult } from "$lib/promiseMap";
 /**
  * Get resources that are associated with the passed calendar
  */
-export async function findMany(calendarId: Hash): Promise<Resource[]> {
-  return await db.resources.where({ calendarId }).toArray();
+export function findMany(calendarId: Hash): Promise<Resource[]> {
+  return db.resources.where({ calendarId }).toArray();
 }
 
 /**
  * Get all calendar resources that are owned by the passed public key.
  */
-export async function findByOwner(
+export function findByOwner(
   calendarId: Hash,
   ownerId: PublicKey,
 ): Promise<Resource[]> {
-  return await db.resources.where({ calendarId, ownerId }).toArray();
+  return db.resources.where({ calendarId, ownerId }).toArray();
 }
 
 /**
  * Get one event by its ID.
  */
-export async function findById(id: Hash): Promise<Resource | undefined> {
-  return await db.resources.get({ id: id });
+export function findById(id: Hash): Promise<Resource | undefined> {
+  return db.resources.get({ id: id });
 }
 
 /**

--- a/src/lib/api/spaces.ts
+++ b/src/lib/api/spaces.ts
@@ -9,25 +9,25 @@ import { promiseResult } from "$lib/promiseMap";
 /**
  * Get spaces that are associated with the passed calendar
  */
-export async function findMany(calendarId: Hash): Promise<Space[]> {
-  return await db.spaces.where({ calendarId }).toArray();
+export function findMany(calendarId: Hash): Promise<Space[]> {
+  return db.spaces.where({ calendarId }).toArray();
 }
 
 /**
  * Get all calendar spaces that are owned by the passed public key.
  */
-export async function findByOwner(
+export function findByOwner(
   calendarId: Hash,
   ownerId: PublicKey,
 ): Promise<Space[]> {
-  return await db.spaces.where({ calendarId, ownerId }).toArray();
+  return db.spaces.where({ calendarId, ownerId }).toArray();
 }
 
 /**
  * Get one event by its ID.
  */
-export async function findById(id: Hash): Promise<Space | undefined> {
-  return await db.spaces.get({ id });
+export function findById(id: Hash): Promise<Space | undefined> {
+  return db.spaces.get({ id });
 }
 
 /**

--- a/src/lib/api/spaces.ts
+++ b/src/lib/api/spaces.ts
@@ -7,14 +7,14 @@ import { promiseResult } from "$lib/promiseMap";
  */
 
 /**
- * Get spaces that are associated with the currently active calendar
+ * Get spaces that are associated with the passed calendar
  */
 export async function findMany(calendarId: Hash): Promise<Space[]> {
   return await db.spaces.where({ calendarId }).toArray();
 }
 
 /**
- * Get all spaces that I am the owner of.
+ * Get all calendar spaces that are owned by the passed public key.
  */
 export async function findByOwner(
   calendarId: Hash,
@@ -24,7 +24,7 @@ export async function findByOwner(
 }
 
 /**
- * Get one event by its ID
+ * Get one event by its ID.
  */
 export async function findById(id: Hash): Promise<Space | undefined> {
   return await db.spaces.get({ id });
@@ -34,6 +34,9 @@ export async function findById(id: Hash): Promise<Space | undefined> {
  * Commands
  */
 
+/**
+ * Create a calendar space.
+ */
 export async function create(calendarId: Hash, fields: SpaceFields): Promise<Hash> {
   const spaceCreated: SpaceCreated = {
     type: "space_created",
@@ -52,6 +55,9 @@ export async function create(calendarId: Hash, fields: SpaceFields): Promise<Has
   return operationId;
 }
 
+/**
+ * Update a calendar space.
+ */
 export async function update(
   spaceId: Hash,
   fields: SpaceFields,
@@ -74,6 +80,9 @@ export async function update(
   return operationId;
 }
 
+/**
+ * Delete a calendar space.
+ */
 export async function deleteSpace(spaceId: Hash): Promise<Hash> {
   const space = await spaces.findById(spaceId);
   const spaceDeleted: SpaceDeleted = {

--- a/src/lib/api/spaces.ts
+++ b/src/lib/api/spaces.ts
@@ -12,32 +12,22 @@ import { promiseResult } from "$lib/promiseMap";
  * Get spaces that are associated with the currently active calendar
  */
 export async function findMany(): Promise<Space[]> {
-  const spaces = await db.spaces.toArray();
-  return spaces;
+  return await db.spaces.toArray();
 }
 
 /**
  * Get all spaces that I am the owner of.
  */
 export async function findMine(): Promise<Space[]> {
-  const myPublicKey = await publicKey();
-  const spaces = (await db.spaces.toArray()).filter(
-    (space) => space.ownerId == myPublicKey,
-  );
-  return spaces;
+  let myPublicKey = await publicKey();
+  return await db.spaces.where({ ownerId: myPublicKey }).toArray();
 }
 
 /**
  * Get one event by its ID
  */
 export async function findById(id: Hash): Promise<Space | undefined> {
-  const space = (await db.spaces.toArray()).filter((space) => space.id == id);
-
-  if (space.length == 0) {
-    return;
-  }
-
-  return space[0];
+  return await db.spaces.get({ id });
 }
 
 /**

--- a/src/lib/api/streams.ts
+++ b/src/lib/api/streams.ts
@@ -4,17 +4,9 @@ import { db } from "$lib/db";
  * Get one event by its ID
  */
 export async function findById(id: Hash): Promise<Stream | undefined> {
-  let streams = (await db.streams.toArray()).filter(
-    (streams) => streams.id == id,
-  );
-
-  if (streams.length == 0) {
-    return;
-  }
-
-  return streams[0];
+  return await db.streams.get({ id });
 }
 
 export async function add(stream: Stream) {
-  await db.streams.add(stream)
+  await db.streams.add(stream);
 }


### PR DESCRIPTION
- use nice Dexie methods like `get` `where` and `filter` for queries
- pass `calendarId` into methods rather than using `getActiveCalendar`
- don't await Dexie db calls in API methods, instead return the promise

NEXT STEPS
- we might be going for a more nested approach to the API (eg. `calendar.events.create(eventFields)`) but that's not part of this PR