### PR TITLE
Fix calendar id not being passed in /events, /spaces and /resources routes

### DIFF
--- a/src/routes/app/events/+page.ts
+++ b/src/routes/app/events/+page.ts
@@ -3,7 +3,7 @@ import { calendars, events } from "$lib/api";
 
 export const load: PageLoad = async () => {
   const activeCalendarId = await calendars.getActiveCalendarId();
-  const eventsList = await events.findMany();
+  const eventsList = await events.findMany(activeCalendarId!);
 
   return { title: "home", activeCalendarId, eventsList };
 };

--- a/src/routes/app/resources/+page.ts
+++ b/src/routes/app/resources/+page.ts
@@ -3,7 +3,7 @@ import { calendars, resources } from "$lib/api";
 
 export const load: PageLoad = async () => {
   const activeCalendarId = await calendars.getActiveCalendarId();
-  const resourcesList = await resources.findMany();
+  const resourcesList = await resources.findMany(activeCalendarId!);
 
   return { title: "resources", activeCalendarId, resourcesList };
 };

--- a/src/routes/app/spaces/+page.ts
+++ b/src/routes/app/spaces/+page.ts
@@ -3,7 +3,7 @@ import { calendars, spaces } from "$lib/api";
 
 export const load: PageLoad = async () => {
   const activeCalendarId = await calendars.getActiveCalendarId();
-  const spacesList = await spaces.findMany();
+  const spacesList = await spaces.findMany(activeCalendarId!);
 
   return { title: "spaces", activeCalendarId, spacesList };
 };


### PR DESCRIPTION
This PR fixes bug where `calendarId` was not passed to `findMany()` API method in the +pages.ts.

Bug was originally caused by API changes to this method in in #129.