### PR TITLE
Enriched queries

### DIFF
--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -148,7 +148,7 @@ async function onBookingResponse(
   meta: StreamMessageMeta,
   data: BookingRequestAccepted["data"] | BookingRequestRejected["data"],
 ) {
-  const request = await bookings.findRequest(data.requestId);
+  const request = await bookings.findById(data.requestId);
   if (request!.resourceType === "resource") {
     const isOwner = await resources.isOwner(request!.resourceId, meta.author);
     if (!isOwner) {

--- a/src/lib/api/bookings.ts
+++ b/src/lib/api/bookings.ts
@@ -7,7 +7,9 @@ import { isSubTimespan } from "$lib/utils";
  * Queries
  */
 
-export function findById(requestId: Hash): Promise<BookingRequest | undefined> {
+export function findById(
+  requestId: Hash,
+): Promise<BookingRequestEnriched | undefined> {
   return db.transaction(
     "r",
     db.bookingRequests,
@@ -15,7 +17,8 @@ export function findById(requestId: Hash): Promise<BookingRequest | undefined> {
     db.spaces,
     db.events,
     async () => {
-      const bookingRequest = await db.bookingRequests.get(requestId);
+      const bookingRequest: BookingRequestEnriched | undefined =
+        await db.bookingRequests.get(requestId);
       if (!bookingRequest) {
         return;
       }
@@ -43,7 +46,7 @@ export function findById(requestId: Hash): Promise<BookingRequest | undefined> {
 export function findAll(
   calendarId: Hash,
   filter: BookingQueryFilter,
-): Promise<BookingRequest[]> {
+): Promise<BookingRequestEnriched[]> {
   return db.transaction(
     "r",
     db.bookingRequests,
@@ -51,7 +54,7 @@ export function findAll(
     db.spaces,
     db.events,
     async () => {
-      const bookingRequests = await db.bookingRequests
+      const bookingRequests: BookingRequestEnriched[] = await db.bookingRequests
         .where({
           calendarId,
           ...filter,
@@ -80,7 +83,10 @@ export function findAll(
 /**
  * Search the database for any pending booking requests matching the passed filter object.
  */
-export function findPending(calendarId: Hash, filter: BookingQueryFilter) {
+export function findPending(
+  calendarId: Hash,
+  filter: BookingQueryFilter,
+): Promise<BookingRequestEnriched[]> {
   return db.transaction(
     "r",
     db.bookingRequests,
@@ -88,7 +94,7 @@ export function findPending(calendarId: Hash, filter: BookingQueryFilter) {
     db.spaces,
     db.events,
     async () => {
-      const bookingRequests = await db.bookingRequests
+      const bookingRequests: BookingRequestEnriched[] = await db.bookingRequests
         .where({
           calendarId,
           status: "pending",

--- a/src/lib/api/bookings.ts
+++ b/src/lib/api/bookings.ts
@@ -7,7 +7,7 @@ import { isSubTimespan } from "$lib/utils";
  * Queries
  */
 
-export function findRequest(
+export function findById(
   requestId: Hash,
 ): Promise<BookingRequest | undefined> {
   return db.bookingRequests.get(requestId);
@@ -236,7 +236,7 @@ async function onBookingRequested(
       await accept(meta.operationId);
     } else {
       // Show toast if we are the owner of the resource and we didn't make the request.
-      const resourceRequest = await bookings.findRequest(meta.operationId);
+      const resourceRequest = await bookings.findById(meta.operationId);
       toast.bookingRequest(resourceRequest!);
     }
   }

--- a/src/lib/api/data.ts
+++ b/src/lib/api/data.ts
@@ -163,9 +163,9 @@ export async function seedData() {
     description: "A grand music festival with various artists.",
     startDate: "2025-01-06T14:00:00Z",
     endDate: "2025-01-06T20:00:00Z",
-    location: `${spaceOneId}`,
+    spaceRequest: `${spaceOneId}`,
     images: [],
-    resources: [`${resourceOneId}`],
+    resourcesRequests: [`${resourceOneId}`],
     links: [],
   });
 
@@ -174,9 +174,9 @@ export async function seedData() {
     description: "An exhibition showcasing modern art.",
     startDate: "2025-02-10T10:00:00.000Z",
     endDate: "2025-02-10T17:00:00.000Z",
-    location: "",
+    spaceRequest: "",
     images: [],
-    resources: [],
+    resourcesRequests: [],
     links: [],
   });
 

--- a/src/lib/api/dependencies.ts
+++ b/src/lib/api/dependencies.ts
@@ -86,7 +86,7 @@ async function onBookingRequest(data: BookingRequested["data"]) {
 async function onBookingResponse(
   data: BookingRequestAccepted["data"] | BookingRequestRejected["data"],
 ) {
-  const request = await bookings.findRequest(data.requestId);
+  const request = await bookings.findById(data.requestId);
   if (!request) {
     throw new Error("resource request not yet received");
   }

--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -22,8 +22,8 @@ export function findMany(calendarId: Hash): Promise<CalendarEvent[]> {
       const events = await db.events.where({ calendarId }).toArray();
       // Add space to each event.
       for (const event of events) {
-        if (event.location) {
-          const request = await db.bookingRequests.get(event.location);
+        if (event.spaceRequest) {
+          const request = await db.bookingRequests.get(event.spaceRequest);
           if (!request) {
             continue;
           }
@@ -52,8 +52,8 @@ export function findByOwner(
       const events = await db.events.where({ ownerId, calendarId }).toArray();
       for (const event of events) {
         // Add space to each event.
-        if (event.location) {
-          const request = await db.bookingRequests.get(event.location);
+        if (event.spaceRequest) {
+          const request = await db.bookingRequests.get(event.spaceRequest);
           if (!request) {
             continue;
           }
@@ -96,8 +96,8 @@ export function findById(id: Hash): Promise<CalendarEvent | undefined> {
     async () => {
       const event = await db.events.get({ id });
       // Add space to event.
-      if (event?.location) {
-        const request = await db.bookingRequests.get(event.location);
+      if (event?.spaceRequest) {
+        const request = await db.bookingRequests.get(event.spaceRequest);
         if (!request) {
           return event;
         }

--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -76,6 +76,8 @@ export function findByOwner(
             resources.push(resource);
           }
         }
+
+        event.resources = resources;
       }
       return events;
     },

--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -12,14 +12,16 @@ import { auth, events, publish } from ".";
 /**
  * Get events that are associated with the passed calendar
  */
-export function findMany(calendarId: Hash): Promise<CalendarEvent[]> {
+export function findMany(calendarId: Hash): Promise<CalendarEventEnriched[]> {
   return db.transaction(
     "r",
     db.events,
     db.bookingRequests,
     db.spaces,
     async () => {
-      const events = await db.events.where({ calendarId }).toArray();
+      const events: CalendarEventEnriched[] = await db.events
+        .where({ calendarId })
+        .toArray();
       // Add space to each event.
       for (const event of events) {
         if (event.spaceRequest) {
@@ -41,7 +43,7 @@ export function findMany(calendarId: Hash): Promise<CalendarEvent[]> {
 export function findByOwner(
   calendarId: Hash,
   ownerId: PublicKey,
-): Promise<CalendarEvent[]> {
+): Promise<CalendarEventEnriched[]> {
   return db.transaction(
     "r",
     db.events,
@@ -49,7 +51,9 @@ export function findByOwner(
     db.resources,
     db.spaces,
     async () => {
-      const events = await db.events.where({ ownerId, calendarId }).toArray();
+      const events: CalendarEventEnriched[] = await db.events
+        .where({ ownerId, calendarId })
+        .toArray();
       for (const event of events) {
         // Add space to each event.
         if (event.spaceRequest) {
@@ -87,14 +91,16 @@ export function findByOwner(
 /**
  * Get one event via its id
  */
-export function findById(id: Hash): Promise<CalendarEvent | undefined> {
+export function findById(id: Hash): Promise<CalendarEventEnriched | undefined> {
   return db.transaction(
     "r",
     db.events,
     db.bookingRequests,
     db.spaces,
     async () => {
-      const event = await db.events.get({ id });
+      const event: CalendarEventEnriched | undefined = await db.events.get({
+        id,
+      });
       // Add space to event.
       if (event?.spaceRequest) {
         const request = await db.bookingRequests.get(event.spaceRequest);

--- a/src/lib/components/EventRow.svelte
+++ b/src/lib/components/EventRow.svelte
@@ -1,7 +1,7 @@
-<script type="ts">
+<script lang="ts">
   // TODO: Define the type of the event prop
 
-  let { event } = $props();
+  let { event }: { event: CalendarEvent } = $props();
 
   // TODO: possibly need to convert date to nice format from ISO 8601. TBC.
 
@@ -19,7 +19,9 @@
     <h3>{event.name}</h3>
     <span>🗓️ {event.startDate}</span>
     <span>🕣 {event.startDate}</span>
-    <span>📍 {event.location ? event.location : "no space yet"}</span>
+    <span
+      >📍 {event.location ? event.location : "no space yet"}</span
+    >
   </div>
 </a>
 

--- a/src/lib/components/EventRow.svelte
+++ b/src/lib/components/EventRow.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   // TODO: Define the type of the event prop
 
-  let { event }: { event: CalendarEvent } = $props();
+  let { event }: { event: CalendarEventEnriched } = $props();
 
   // TODO: possibly need to convert date to nice format from ISO 8601. TBC.
 

--- a/src/lib/components/EventRow.svelte
+++ b/src/lib/components/EventRow.svelte
@@ -20,7 +20,7 @@
     <span>🗓️ {event.startDate}</span>
     <span>🕣 {event.startDate}</span>
     <span
-      >📍 {event.location ? event.location : "no space yet"}</span
+      >📍 {event.space ? event.space : "no space yet"}</span
     >
   </div>
 </a>

--- a/src/lib/components/EventRow.svelte
+++ b/src/lib/components/EventRow.svelte
@@ -19,9 +19,7 @@
     <h3>{event.name}</h3>
     <span>🗓️ {event.startDate}</span>
     <span>🕣 {event.startDate}</span>
-    <span
-      >📍 {event.space ? event.space : "no space yet"}</span
-    >
+    <span>📍 {event.space ? event.space : "no space yet"}</span>
   </div>
 </a>
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -93,7 +93,7 @@ export const eventSchema = z.object({
   endDate: z.string().min(1, "Access end time is required"),
   publicStartDate: z.string().min(1, "Event start time is required"),
   publicEndDate: z.string(),
-  resources: z.array(z.string()).optional(),
+  resourceRequests: z.array(z.string()).optional(),
   links: z
     .array(linkSchema)
     .optional()

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -647,8 +647,11 @@ type BookingRequest = {
   id: Hash;
   calendarId: Hash;
   eventId: Hash;
+  event?: CalendarEvent;
   requester: PublicKey;
   resourceId: Hash;
+  resource?: Resource;
+  space?: Space;
   resourceType: ResourceType;
   resourceOwner: PublicKey;
   message: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -627,11 +627,6 @@ type CalendarEvent = {
   ownerId: PublicKey;
 } & EventFields;
 
-type CalendarEventEnriched = {
-  space?: Space;
-  resources?: Resource[];
-} & CalendarEvent;
-
 type Space = {
   id: Hash;
   calendarId: Hash;
@@ -659,12 +654,6 @@ type BookingRequest = {
   isValid: "true" | "false";
   status: "accepted" | "rejected" | "pending";
 };
-
-type BookingRequestEnriched = {
-  event?: CalendarEvent;
-  resource?: Resource;
-  space?: Space;
-} & BookingRequest;
 
 type ResourceType = "space" | "resource";
 
@@ -701,3 +690,14 @@ type BookingQueryFilter = {
   resourceOwner?: PublicKey;
   isValid?: "true" | "false";
 };
+
+type CalendarEventEnriched = {
+  space?: Space;
+  resources?: Resource[];
+} & CalendarEvent;
+
+type BookingRequestEnriched = {
+  event?: CalendarEvent;
+  resource?: Resource;
+  space?: Space;
+} & BookingRequest;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -625,6 +625,7 @@ type CalendarEvent = {
   id: Hash;
   calendarId: Hash;
   ownerId: PublicKey;
+  space?: Space;
 } & EventFields;
 
 type Space = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -335,12 +335,12 @@ type ResourceFields = {
 type EventFields = {
   name: string;
   description: string;
-  location?: SpaceRequestId; // ref to a space
+  spaceRequest?: SpaceRequestId; // ref to a space
   startDate: string; // allocated time of a space
   endDate: string; // allocated time of a space
   publicStartDate?: string; // public facing
   publicEndDate?: string; // public facing
-  resources?: ReservationRequestId[];
+  resourcesRequests?: ReservationRequestId[];
   links: Link[];
   images: Image[];
 };
@@ -626,6 +626,7 @@ type CalendarEvent = {
   calendarId: Hash;
   ownerId: PublicKey;
   space?: Space;
+  resources?: Resource[];
 } & EventFields;
 
 type Space = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -625,9 +625,12 @@ type CalendarEvent = {
   id: Hash;
   calendarId: Hash;
   ownerId: PublicKey;
+} & EventFields;
+
+type CalendarEventEnriched = {
   space?: Space;
   resources?: Resource[];
-} & EventFields;
+} & CalendarEvent;
 
 type Space = {
   id: Hash;
@@ -647,11 +650,8 @@ type BookingRequest = {
   id: Hash;
   calendarId: Hash;
   eventId: Hash;
-  event?: CalendarEvent;
   requester: PublicKey;
   resourceId: Hash;
-  resource?: Resource;
-  space?: Space;
   resourceType: ResourceType;
   resourceOwner: PublicKey;
   message: string;
@@ -659,6 +659,12 @@ type BookingRequest = {
   isValid: "true" | "false";
   status: "accepted" | "rejected" | "pending";
 };
+
+type BookingRequestEnriched = {
+  event?: CalendarEvent;
+  resource?: Resource;
+  space?: Space;
+} & BookingRequest;
 
 type ResourceType = "space" | "resource";
 

--- a/tests/api/booking.test.ts
+++ b/tests/api/booking.test.ts
@@ -14,7 +14,7 @@ import { beforeEach, expect, test } from "vitest";
 import { mockIPC } from "@tauri-apps/api/mocks";
 
 beforeEach(async () => {
-  mockIPC((cmd, args) => {
+  mockIPC((cmd) => {
     if (cmd === "public_key") {
       return OWNER_PUBLIC_KEY;
     }


### PR DESCRIPTION
I've made all the following changes, opting for adding entire objects (`space`, `event` etc...) onto the return types for now. The only one I couldn't do is `user` on the booking queries, this was because `Dexie` transactions have a limit to how many database tables they can access, and we reached that limit.... I suggest we make a slightly ugly loop wherever the username is required in the frontend until we find a better solution.

- events general queries
    - queries
        - `events.findByOwner`
        - `event.findById`
        - `event.findMany`
    - enrichment
        - [x] space
- events for dashboard
    - queries
        - `events.findMy` 
    - enrichment
        - for each event we need bookings associated with that event.
            - [x] resource
- bookings (this API only publicly deals with `BookingRequests` now)
    - queries
        - `findById`
        - `findAll`
        - `findPending`
    - enrichment
        - [x] event
        - [x] resource
        - [x] space
        - [ ] ~~user~~
    