### PR TITLE
Dashboard UI

### DIFF
--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -62,6 +62,9 @@ export function findByOwner(
             continue;
           }
           event.space = await db.spaces.get({ id: request.resourceId });
+          if (event.space) {
+            event.space.bookingRequest = request;
+          }
         }
 
         if (!event.resources) {
@@ -69,14 +72,15 @@ export function findByOwner(
         }
 
         // Add resources to each event.
-        const resources: Resource[] = [];
+        const resources: CalendarEventResourceEnriched[] = [];
         for (const requestId of event.resources) {
           const request = await db.bookingRequests.get(requestId);
           if (!request) {
             continue;
           }
-          const resource = await db.resources.get(request.resourceId);
+          const resource: CalendarEventResourceEnriched | undefined = await db.resources.get(request.resourceId);
           if (resource) {
+            resource.bookingRequest = request;
             resources.push(resource);
           }
         }

--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -78,7 +78,8 @@ export function findByOwner(
           if (!request) {
             continue;
           }
-          const resource: CalendarEventResourceEnriched | undefined = await db.resources.get(request.resourceId);
+          const resource: CalendarEventResourceEnriched | undefined =
+            await db.resources.get(request.resourceId);
           if (resource) {
             resource.bookingRequest = request;
             resources.push(resource);

--- a/src/lib/api/resources.ts
+++ b/src/lib/api/resources.ts
@@ -27,7 +27,7 @@ export function findByOwner(
       .toArray();
     // For each space check if there are any pending bookings
     for (const resource of myResources) {
-      resource.pendingRequests = await db.bookingRequests
+      resource.pendingBookingRequests = await db.bookingRequests
         .where({ resourceId: resource.id })
         .toArray();
     }

--- a/src/lib/api/resources.ts
+++ b/src/lib/api/resources.ts
@@ -20,9 +20,9 @@ export function findMany(calendarId: Hash): Promise<Resource[]> {
 export function findByOwner(
   calendarId: Hash,
   ownerId: PublicKey,
-): Promise<MyResourcesEnriched[]> {
+): Promise<OwnerResourceEnriched[]> {
   return db.transaction("r", db.resources, db.bookingRequests, async () => {
-    const myResources: MyResourcesEnriched[] = await db.resources
+    const myResources: OwnerResourceEnriched[] = await db.resources
       .where({ calendarId, ownerId })
       .toArray();
     // For each space check if there are any pending bookings

--- a/src/lib/api/spaces.ts
+++ b/src/lib/api/spaces.ts
@@ -27,7 +27,7 @@ export function findByOwner(
       .toArray();
     // For each space check if there are any pending bookings
     for (const space of mySpaces) {
-      space.pendingRequests = await db.bookingRequests
+      space.pendingBookingRequests = await db.bookingRequests
         .where({ resourceId: space.id })
         .toArray();
     }

--- a/src/lib/api/spaces.ts
+++ b/src/lib/api/spaces.ts
@@ -20,9 +20,9 @@ export function findMany(calendarId: Hash): Promise<Space[]> {
 export function findByOwner(
   calendarId: Hash,
   ownerId: PublicKey,
-): Promise<MySpacesEnriched[]> {
+): Promise<OwnerSpaceEnriched[]> {
   return db.transaction("r", db.spaces, db.bookingRequests, async () => {
-    const mySpaces: MySpacesEnriched[] = await db.spaces
+    const mySpaces: OwnerSpaceEnriched[] = await db.spaces
       .where({ calendarId, ownerId })
       .toArray();
     // For each space check if there are any pending bookings

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -669,6 +669,8 @@ type Settings = {
 /**
  * (´ヮ´)八(*ﾟ▽ﾟ*)
  * Application Data
+ *
+ * Enriched data used for the UI
  */
 
 type CalendarId = Hash;
@@ -696,3 +698,11 @@ type BookingRequestEnriched = {
   resource?: Resource;
   space?: Space;
 } & BookingRequest;
+
+type MyResourcesEnriched = {
+  pendingRequests?: BookingRequest[];
+} & Resource;
+
+type MySpacesEnriched = {
+  pendingRequests?: BookingRequest[];
+} & Space;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -705,10 +705,10 @@ type BookingRequestEnriched = {
   space?: Space;
 } & BookingRequest;
 
-type MyResourcesEnriched = {
+type OwnerResourceEnriched = {
   pendingBookingRequests?: BookingRequest[];
 } & Resource;
 
-type MySpacesEnriched = {
+type OwnerSpaceEnriched = {
   pendingBookingRequests?: BookingRequest[];
 } & Space;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -157,9 +157,9 @@ type SystemMessage = SubscribedToTopic | NetworkEvent;
  */
 type SubscribedToTopic =
   | {
-      event: "subscribed_to_persisted_topic";
-      topic: string;
-    }
+    event: "subscribed_to_persisted_topic";
+    topic: string;
+  }
   | { event: "subscribed_to_ephemeral_topic"; topic: string };
 
 /**
@@ -689,9 +689,15 @@ type BookingQueryFilter = {
 };
 
 type CalendarEventEnriched = {
-  space?: Space;
-  resources?: Resource[];
+  space?: {
+    bookingRequest?: BookingRequest
+  } & Space;
+  resources?: CalendarEventResourceEnriched[];
 } & CalendarEvent;
+
+type CalendarEventResourceEnriched = {
+  bookingRequest?: BookingRequest
+} & Resource
 
 type BookingRequestEnriched = {
   event?: CalendarEvent;
@@ -700,9 +706,9 @@ type BookingRequestEnriched = {
 } & BookingRequest;
 
 type MyResourcesEnriched = {
-  pendingRequests?: BookingRequest[];
+  pendingBookingRequests?: BookingRequest[];
 } & Resource;
 
 type MySpacesEnriched = {
-  pendingRequests?: BookingRequest[];
+  pendingBookingRequests?: BookingRequest[];
 } & Space;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -157,9 +157,9 @@ type SystemMessage = SubscribedToTopic | NetworkEvent;
  */
 type SubscribedToTopic =
   | {
-    event: "subscribed_to_persisted_topic";
-    topic: string;
-  }
+      event: "subscribed_to_persisted_topic";
+      topic: string;
+    }
   | { event: "subscribed_to_ephemeral_topic"; topic: string };
 
 /**
@@ -690,14 +690,14 @@ type BookingQueryFilter = {
 
 type CalendarEventEnriched = {
   space?: {
-    bookingRequest?: BookingRequest
+    bookingRequest?: BookingRequest;
   } & Space;
   resources?: CalendarEventResourceEnriched[];
 } & CalendarEvent;
 
 type CalendarEventResourceEnriched = {
-  bookingRequest?: BookingRequest
-} & Resource
+  bookingRequest?: BookingRequest;
+} & Resource;
 
 type BookingRequestEnriched = {
   event?: CalendarEvent;

--- a/src/routes/app/dashboard/+page.svelte
+++ b/src/routes/app/dashboard/+page.svelte
@@ -25,7 +25,7 @@
 
 <h1>Dashboard</h1>
 
-<section>
+<section class="mb-8">
   <h3>pending requests</h3>
   {#if $pendingRequests?.length > 0}
     {#each $pendingRequests as request (request.id)}
@@ -35,7 +35,7 @@
     <p>no pending requests, you are all caught up ٩(ˊᗜˋ*)و</p>
   {/if}
 </section>
-<section>
+<section class="mb-8">
   <h3>my events & requests</h3>
   {#if $myEvents?.length > 0}
     {#each $myEvents as event (event.id)}
@@ -59,7 +59,7 @@
     <p>you don't have any events yet</p>
   {/if}
 </section>
-<section>
+<section class="mb-8">
   <h3>my spaces</h3>
   {#if $mySpaces?.length > 0}
     {#each $mySpaces as space (space.id)}
@@ -77,7 +77,7 @@
     <p>you don't have any spaces yet</p>
   {/if}
 </section>
-<section>
+<section class="mb-8">
   <h3>my resources</h3>
   {#if $myResources?.length > 0}
     {#each $myResources as resource (resource.id)}

--- a/src/routes/app/dashboard/+page.svelte
+++ b/src/routes/app/dashboard/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { PageProps } from "./$types";
   import RequestDialog from "./RequestDialog.svelte";
-  import { bookings } from "$lib/api";
+  import { bookings, events, resources, spaces } from "$lib/api";
   import { liveQuery } from "dexie";
 
   let { data }: PageProps = $props();
@@ -9,15 +9,89 @@
   let pendingRequests = liveQuery(() =>
     bookings.findPending(data.activeCalendarId!, {}),
   );
+
+  let mySpaces = liveQuery(() =>
+    spaces.findByOwner(data.activeCalendarId!, data.publicKey),
+  );
+
+  let myResources = liveQuery(() =>
+    resources.findByOwner(data.activeCalendarId!, data.publicKey),
+  );
+
+  let myEvents = liveQuery(() =>
+    events.findByOwner(data.activeCalendarId!, data.publicKey),
+  );
 </script>
 
 <h1>Dashboard</h1>
 
 <section>
-  {#if $pendingRequests}
-    <h3>Pending requests</h3>
+  <h3>pending requests</h3>
+  {#if $pendingRequests?.length > 0}
     {#each $pendingRequests as request (request.id)}
       <RequestDialog {request} />
     {/each}
+  {:else}
+    <p>no pending requests, you are all caught up ٩(ˊᗜˋ*)و</p>
+  {/if}
+</section>
+<section>
+  <h3>my events & requests</h3>
+  {#if $myEvents?.length > 0}
+    {#each $myEvents as event (event.id)}
+      <a
+        href={`/app/events/${event.id}`}
+        class="p-2 border-black border justify-between flex"
+      >
+        {event.name}
+        {event.startDate}
+        {event.space ? event.space.name : "no space yet"}
+        {#if event.resources}
+          {#each event.resources as resource (resource.id)}
+            <div>
+              <p>{resource.name}</p>
+            </div>
+          {/each}
+        {/if}
+      </a>
+    {/each}
+  {:else}
+    <p>you don't have any events yet</p>
+  {/if}
+</section>
+<section>
+  <h3>my spaces</h3>
+  {#if $mySpaces?.length > 0}
+    {#each $mySpaces as space (space.id)}
+      <a
+        href={`/app/spaces/${space.id}`}
+        class="p-2 border-black border justify-between flex"
+      >
+        <p>{space.name}</p>
+        {#if space.pendingRequests}
+          <p>pending requests ({space.pendingRequests.length})</p>
+        {/if}
+      </a>
+    {/each}
+  {:else}
+    <p>you don't have any spaces yet</p>
+  {/if}
+</section>
+<section>
+  <h3>my resources</h3>
+  {#if $myResources?.length > 0}
+    {#each $myResources as resource (resource.id)}
+      <a
+        href={`/app/resources/${resource.id}`}
+        class="p-2 border-black border justify-between flex"
+      >
+        <p>{resource.name}</p>
+        {#if resource.pendingRequests}
+          <p>pending requests ({resource.pendingRequests.length})</p>
+        {/if}
+      </a>
+    {/each}
+  {:else}
+    <p>you don't have any resources yet</p>
   {/if}
 </section>

--- a/src/routes/app/dashboard/+page.svelte
+++ b/src/routes/app/dashboard/+page.svelte
@@ -3,6 +3,7 @@
   import RequestDialog from "./RequestDialog.svelte";
   import { bookings, events, resources, spaces } from "$lib/api";
   import { liveQuery } from "dexie";
+  import PlusIcon from "$lib/components/icons/plusIcon.svelte";
 
   let { data }: PageProps = $props();
 
@@ -55,6 +56,13 @@
         {/if}
       </a>
     {/each}
+    <a
+      href="/app/events/create"
+      class="rounded-full border-black border p-2 inline-block"
+    >
+      <PlusIcon size={10} />
+      <span class="sr-only">Add event</span>
+    </a>
   {:else}
     <p>you don't have any events yet</p>
   {/if}
@@ -76,6 +84,13 @@
   {:else}
     <p>you don't have any spaces yet</p>
   {/if}
+  <a
+    href="/app/spaces/create"
+    class="rounded-full border-black border p-2 inline-block"
+  >
+    <PlusIcon size={10} />
+    <span class="sr-only">Add event</span>
+  </a>
 </section>
 <section class="mb-8">
   <h3>my resources</h3>
@@ -94,4 +109,11 @@
   {:else}
     <p>you don't have any resources yet</p>
   {/if}
+  <a
+    href="/app/spaces/create"
+    class="rounded-full border-black border p-2 inline-block"
+  >
+    <PlusIcon size={10} />
+    <span class="sr-only">Add event</span>
+  </a>
 </section>

--- a/src/routes/app/dashboard/+page.svelte
+++ b/src/routes/app/dashboard/+page.svelte
@@ -39,17 +39,17 @@
   <h3>my events & requests</h3>
   {#if $myEvents?.length > 0}
     {#each $myEvents as event (event.id)}
-      <a
-        href={`/app/events/${event.id}`}
-        class="p-2 border-black border justify-between flex"
-      >
-        {event.name}
-        {event.startDate}
-        {event.space ? event.space.name : "no space yet"}
+      <a href={`/app/events/${event.id}`} class="p-2 border-black border block">
+        <h4>{event.name}</h4>
+        <p>{event.startDate}</p>
+        <p>{event.space ? event.space.name : "no space yet"}</p>
+        {#if event.space}
+          <div>{event.space.name} {event.space.bookingRequest?.status}</div>
+        {/if}
         {#if event.resources}
           {#each event.resources as resource (resource.id)}
             <div>
-              <p>{resource.name}</p>
+              <p>{resource.name} {resource.bookingRequest?.status}</p>
             </div>
           {/each}
         {/if}
@@ -68,8 +68,8 @@
         class="p-2 border-black border justify-between flex"
       >
         <p>{space.name}</p>
-        {#if space.pendingRequests}
-          <p>pending requests ({space.pendingRequests.length})</p>
+        {#if space.pendingBookingRequests}
+          <p>pending requests ({space.pendingBookingRequests.length})</p>
         {/if}
       </a>
     {/each}
@@ -86,8 +86,8 @@
         class="p-2 border-black border justify-between flex"
       >
         <p>{resource.name}</p>
-        {#if resource.pendingRequests}
-          <p>pending requests ({resource.pendingRequests.length})</p>
+        {#if resource.pendingBookingRequests}
+          <p>pending requests ({resource.pendingBookingRequests.length})</p>
         {/if}
       </a>
     {/each}

--- a/src/routes/app/dashboard/+page.ts
+++ b/src/routes/app/dashboard/+page.ts
@@ -1,11 +1,7 @@
 import type { PageLoad } from "./$types";
-import { calendars } from "$lib/api";
 
 export const load: PageLoad = async () => {
-  const activeCalendarId = await calendars.getActiveCalendarId();
-
   return {
     title: `dashboard`,
-    activeCalendarId,
   };
 };


### PR DESCRIPTION
This PR completes #213 by adding the following:

- Enrich Calendar events further by attaching booking request so we can show status of space and resource bookings in the UI (required for dashboard UI)
- Enrich `spaces.findByOwner` so it returns any pending requests attached to that space. (required for dashboard UI)
- Enrich `resources.findByOwner` so it returns any pending requests attached to that spaces. (required for dashboard UI).
- Render my events, my spaces, my resources to dashboard as live queries.
- Add some nice messages for the user if they have no pending requests/events/spaces/resources.

## Still to do

- Style dashboard UI