### PR TITLE
Only create users once they have been given access

### DIFF
--- a/src/lib/api/access.ts
+++ b/src/lib/api/access.ts
@@ -291,8 +291,7 @@ async function onCalendarAccessRequested(
   };
 
   await db.accessRequests.add(accessRequest);
-  const publicKey = await identity.publicKey();
-  const accessStatus = await checkStatus(publicKey, calendarId);
+  const accessStatus = await checkStatus(meta.author, calendarId);
 
   // Show toast to user with request if owner or admin.
   const amOwner = await calendars.amOwner(calendarId);

--- a/src/routes/app/admin/RequestDialog.svelte
+++ b/src/routes/app/admin/RequestDialog.svelte
@@ -7,11 +7,13 @@
 </script>
 
 <AlertDialog.Root bind:open>
-  <AlertDialog.Trigger class="button">
-    <p>
+  <AlertDialog.Trigger class="button flex justify-between w-full text-left">
+    <span>
       {data.name ? data.name : "Anon"}
+    </span>
+    <span>
       {isAccessRequest ? "pending" : (data as User).role}
-    </p>
+    </span>
     <AccessRoleDialog {data} bind:open />
   </AlertDialog.Trigger>
 </AlertDialog.Root>


### PR DESCRIPTION
This PR fixes bug where users was created at the calendar access request stage instead of when they were given access to the calendar.