### PR TITLE
Upcoming bookings and resource requests on event

### DIFF
--- a/src/lib/api/bookings.ts
+++ b/src/lib/api/bookings.ts
@@ -58,13 +58,13 @@ export function findAll(
 
       if (from) {
         query.filter((request) => {
-          return request.timeSpan.start >= from;
+          return new Date(request.timeSpan.start) >= from;
         });
       }
 
       if (to) {
         query.filter((request) => {
-          return request.timeSpan.start <= to;
+          return new Date(request.timeSpan.start) <= to;
         });
       }
 

--- a/src/lib/components/UpcomingBookings.svelte
+++ b/src/lib/components/UpcomingBookings.svelte
@@ -15,10 +15,13 @@
   <section>
     <h3>Upcoming bookings</h3>
     {#each $upcomingBookings as booking (booking.id)}
-      <a href={`/app/events/${booking.eventId}`}>
-        {booking.event?.name}
-        {booking.event?.startDate}
-        {booking.status}
+      <a
+        href={`/app/events/${booking.eventId}`}
+        class="block border border-black p-2 w-full text-left"
+      >
+        <p>{booking.event?.name}</p>
+        <p>{booking.event?.startDate}</p>
+        <p>{booking.status}</p>
       </a>
     {/each}
   </section>

--- a/src/lib/components/UpcomingBookings.svelte
+++ b/src/lib/components/UpcomingBookings.svelte
@@ -1,4 +1,7 @@
-<!-- Upcoming Bookings component that shown to resource/space owners when viewing a space/resource -->
+<!--
+  Upcoming Bookings component 
+  displayed to resource/space owners when viewing a space/resource
+-->
 
 <script lang="ts">
   import type { Observable } from "dexie";

--- a/src/lib/components/UpcomingBookings.svelte
+++ b/src/lib/components/UpcomingBookings.svelte
@@ -1,0 +1,22 @@
+<!-- Upcoming Bookings component that shown to resource/space owners when viewing a space/resource -->
+
+<script lang="ts">
+  import type { Observable } from "dexie";
+
+  let {
+    upcomingBookings,
+  }: { upcomingBookings: Observable<BookingRequestEnriched[]> } = $props();
+</script>
+
+{#if $upcomingBookings?.length > 0}
+  <section>
+    <h3>Upcoming bookings</h3>
+    {#each $upcomingBookings as booking (booking.id)}
+      <a href={`/app/events/${booking.eventId}`}>
+        {booking.event?.name}
+        {booking.event?.startDate}
+        {booking.status}
+      </a>
+    {/each}
+  </section>
+{/if}

--- a/src/routes/app/events/[id]/+page.svelte
+++ b/src/routes/app/events/[id]/+page.svelte
@@ -1,12 +1,42 @@
 <script lang="ts">
   import type { PageProps } from "./$types";
+  import { liveQuery } from "dexie";
+  import type { Observable } from "dexie";
+  import { bookings } from "$lib/api";
 
   let { data }: PageProps = $props();
+
+  let upcomingBookings: Observable<BookingRequestEnriched[]>;
+
+  if (data.userRole === "admin") {
+    // TODO: Perhaps adjust to account for bookings taking place right now.
+    upcomingBookings = liveQuery(() =>
+      bookings.findAll({
+        calendarId: data.activeCalendarId,
+        eventId: data.event.id,
+      }),
+    );
+  }
 </script>
 
-<br />
-<br />
-<br />
+<h1>{data.event.name}</h1>
+{#if data.userRole === "admin" && $upcomingBookings?.length > 0}
+  <section>
+    <h3>Requests</h3>
+    {#each $upcomingBookings as booking (booking.id)}
+      <div
+        class="border border-black p-2 flex justify-between w-full text-left"
+      >
+        <span
+          >{booking.resource?.name
+            ? booking.resource?.name
+            : "No name yet"}</span
+        >
+        <span>{booking.status}</span>
+      </div>
+    {/each}
+  </section>
+{/if}
 <pre>{JSON.stringify(data.event)}</pre>
 {#if data.userRole == "admin"}
   <a href="/app/events/{data.event!.id}/edit">Edit</a>

--- a/src/routes/app/events/[id]/+page.ts
+++ b/src/routes/app/events/[id]/+page.ts
@@ -1,5 +1,6 @@
 import type { PageLoad } from "./$types";
 import { events, users } from "$lib/api";
+import { error } from "@sveltejs/kit";
 
 export const load: PageLoad = async ({ params, parent }) => {
   const parentData = await parent();
@@ -9,6 +10,12 @@ export const load: PageLoad = async ({ params, parent }) => {
   const eventId = params.id;
 
   const event = await events.findById(eventId);
+
+  if (!event) {
+    error(404, {
+      message: "Resource not found",
+    });
+  }
 
   return { title: "events", event, userRole };
 };

--- a/src/routes/app/resources/[id]/+page.svelte
+++ b/src/routes/app/resources/[id]/+page.svelte
@@ -1,12 +1,35 @@
 <script lang="ts">
   import type { PageProps } from "./$types";
+  import { liveQuery } from "dexie";
+  import { bookings } from "$lib/api";
 
   let { data }: PageProps = $props();
+
+  let now = new Date();
+
+  // TODO: Perhaps adjust to account for bookings taking place right now.
+  let upcomingBookings = liveQuery(() =>
+    bookings.findAll({
+      calendarId: data.activeCalendarId,
+      resourceId: data.resource.id,
+      from: now,
+    }),
+  );
 </script>
 
-<br />
-<br />
-<br />
+<h1>{data.resource.name}</h1>
+<section>
+  <h3>Upcoming bookings</h3>
+  {#if $upcomingBookings?.length > 0}
+    {#each $upcomingBookings as booking (booking.id)}
+      <a href={`/app/events/${booking.eventId}`}>
+        {booking.event?.name}
+        {booking.event?.startDate}
+        {booking.status}
+      </a>
+    {/each}
+  {/if}
+</section>
 <pre>{JSON.stringify(data.resource)}</pre>
 {#if data.userRole == "admin"}
   <a href="/app/resources/{data.resource!.id}/edit">Edit</a>

--- a/src/routes/app/resources/[id]/+page.svelte
+++ b/src/routes/app/resources/[id]/+page.svelte
@@ -1,35 +1,32 @@
 <script lang="ts">
   import type { PageProps } from "./$types";
   import { liveQuery } from "dexie";
+  import type { Observable } from "dexie";
   import { bookings } from "$lib/api";
+  import UpcomingBookings from "$lib/components/UpcomingBookings.svelte";
 
   let { data }: PageProps = $props();
 
   let now = new Date();
+  let upcomingBookings: Observable<BookingRequestEnriched[]>;
+  let amOwner = data.resource.ownerId === data.publicKey;
 
-  // TODO: Perhaps adjust to account for bookings taking place right now.
-  let upcomingBookings = liveQuery(() =>
-    bookings.findAll({
-      calendarId: data.activeCalendarId,
-      resourceId: data.resource.id,
-      from: now,
-    }),
-  );
+  if (amOwner) {
+    // TODO: Perhaps adjust to account for bookings taking place right now.
+    upcomingBookings = liveQuery(() =>
+      bookings.findAll({
+        calendarId: data.activeCalendarId,
+        resourceId: data.resource.id,
+        from: now,
+      }),
+    );
+  }
 </script>
 
 <h1>{data.resource.name}</h1>
-<section>
-  <h3>Upcoming bookings</h3>
-  {#if $upcomingBookings?.length > 0}
-    {#each $upcomingBookings as booking (booking.id)}
-      <a href={`/app/events/${booking.eventId}`}>
-        {booking.event?.name}
-        {booking.event?.startDate}
-        {booking.status}
-      </a>
-    {/each}
-  {/if}
-</section>
+{#if amOwner}
+  <UpcomingBookings {upcomingBookings} />
+{/if}
 <pre>{JSON.stringify(data.resource)}</pre>
 {#if data.userRole == "admin"}
   <a href="/app/resources/{data.resource!.id}/edit">Edit</a>

--- a/src/routes/app/resources/[id]/+page.ts
+++ b/src/routes/app/resources/[id]/+page.ts
@@ -1,10 +1,16 @@
 import type { PageLoad } from "./$types";
 import { resources, users } from "$lib/api";
+import { error } from "@sveltejs/kit";
 
 export const load: PageLoad = async ({ params, parent }) => {
   const resourceId = params.id;
-
   const resource = await resources.findById(resourceId);
+
+  if (!resource || !resource.id) {
+    error(404, {
+      message: "Resource not found",
+    });
+  }
 
   const parentData = await parent();
   const { activeCalendarId, publicKey } = parentData;

--- a/src/routes/app/resources/[id]/+page.ts
+++ b/src/routes/app/resources/[id]/+page.ts
@@ -6,7 +6,7 @@ export const load: PageLoad = async ({ params, parent }) => {
   const resourceId = params.id;
   const resource = await resources.findById(resourceId);
 
-  if (!resource || !resource.id) {
+  if (!resource) {
     error(404, {
       message: "Resource not found",
     });

--- a/src/routes/app/spaces/[id]/+page.svelte
+++ b/src/routes/app/spaces/[id]/+page.svelte
@@ -1,14 +1,32 @@
 <script lang="ts">
   import type { PageProps } from "./$types";
+  import { liveQuery } from "dexie";
+  import type { Observable } from "dexie";
+  import { bookings } from "$lib/api";
+  import UpcomingBookings from "$lib/components/UpcomingBookings.svelte";
 
   let { data }: PageProps = $props();
+
+  let now = new Date();
+  let upcomingBookings: Observable<BookingRequestEnriched[]>;
+  let amOwner = data.space.ownerId === data.publicKey;
+
+  if (amOwner) {
+    // TODO: Perhaps adjust to account for bookings taking place right now.
+    upcomingBookings = liveQuery(() =>
+      bookings.findAll({
+        calendarId: data.activeCalendarId,
+        resourceId: data.space.id,
+        from: now,
+      }),
+    );
+  }
 </script>
 
-<h1>Space page</h1>
-
-<br />
-<br />
-<br />
+<h1>{data.space.name}</h1>
+{#if amOwner}
+  <UpcomingBookings {upcomingBookings} />
+{/if}
 <pre>{JSON.stringify(data.space)}</pre>
 {#if data.userRole == "admin"}
   <a href="/app/spaces/{data.space!.id}/edit">Edit</a>

--- a/src/routes/app/spaces/[id]/+page.ts
+++ b/src/routes/app/spaces/[id]/+page.ts
@@ -1,9 +1,16 @@
 import type { PageLoad } from "./$types";
 import { spaces, users } from "$lib/api";
+import { error } from "@sveltejs/kit";
 
 export const load: PageLoad = async ({ params, parent }) => {
   const spaceId = params.id;
   const space = await spaces.findById(spaceId);
+
+  if (!space || !space.id) {
+    error(404, {
+      message: "Resource not found",
+    });
+  }
 
   const parentData = await parent();
   const { activeCalendarId, publicKey } = parentData;

--- a/src/routes/app/spaces/[id]/+page.ts
+++ b/src/routes/app/spaces/[id]/+page.ts
@@ -6,7 +6,7 @@ export const load: PageLoad = async ({ params, parent }) => {
   const spaceId = params.id;
   const space = await spaces.findById(spaceId);
 
-  if (!space || !space.id) {
+  if (!space) {
     error(404, {
       message: "Resource not found",
     });


### PR DESCRIPTION
This PR adds the following:
- Add Upcoming bookings to resources and spaces pages visible to the owners of a space/resource. 
- Add Resource requests and their status visible to events page visible to admins.
- Fix a bug in `bookings.findAll` where from/to queries where comparing a date against a string.

Closes #201 