### PR TITLE
Hash routing

### DIFF
--- a/src/lib/components/CalendarForm.svelte
+++ b/src/lib/components/CalendarForm.svelte
@@ -46,7 +46,7 @@
       // Reload data all data in the app as we changed to a new calendar.
       await invalidateAll();
       // TODO: Automatically reload app data when active calendar changes.
-      goto(`/app/events`);
+      goto(`#/app/events`);
     } catch (error) {
       console.error("Error creating calendar: ", error);
       toast.error("Error creating calendar!");
@@ -60,7 +60,7 @@
     try {
       await calendars.update(calendarId, payload);
       toast.success("Calendar updated!");
-      goto(`/app/events`);
+      goto(`#/app/events`);
     } catch (error) {
       console.error("Error updating calendar: ", error);
       toast.error("Error updating calendar!");

--- a/src/lib/components/CalendarSelector.svelte
+++ b/src/lib/components/CalendarSelector.svelte
@@ -47,8 +47,8 @@
               >{calendar.name}</Select.Item
             >
           {/each}
-          <a href="/join">Join Calendar</a>
-          <a href="/create">+ Create new calendar</a>
+          <a href="#/join">Join Calendar</a>
+          <a href="#/create">+ Create new calendar</a>
         </Select.Viewport>
       </Select.Content>
     </Select.Portal>

--- a/src/lib/components/EventRow.svelte
+++ b/src/lib/components/EventRow.svelte
@@ -9,7 +9,7 @@
   // let tagColours = ["bg-yellow-light", "bg-fluro-green-light", "bg-red-light"];
 </script>
 
-<a href={`/app/events/${event.id}`} class="flex border-black border event-row">
+<a href={`#/app/events/${event.id}`} class="flex border-black border event-row">
   <img
     src={event.images[0]}
     alt=""

--- a/src/lib/components/dialog/Delete.svelte
+++ b/src/lib/components/dialog/Delete.svelte
@@ -37,7 +37,7 @@
       toast.success(`Successfully deleted ${name}`);
       // close the dialog
       open = false;
-      goto(`/app/${type}s`);
+      goto(`#/app/${type}s`);
     } catch (error) {
       open = false;
       toast.error(`Failed to delete ${name}`);

--- a/src/routes/(unauthed)/join/+page.svelte
+++ b/src/routes/(unauthed)/join/+page.svelte
@@ -29,7 +29,7 @@
       return;
     }
 
-    goto(`/request`);
+    goto(`#/request`);
   }
 </script>
 

--- a/src/routes/(unauthed)/request/+page.svelte
+++ b/src/routes/(unauthed)/request/+page.svelte
@@ -19,7 +19,7 @@
 
     if (accessStatus == "accepted") {
       toast.success("access accepted!");
-      goto("/app/events");
+      goto("#/app/events");
     } else if (accessStatus == "rejected") {
       toast.error("access rejected!");
       goto("/");
@@ -61,7 +61,7 @@
 {#if requestStatus == "pending"}
   <p>
     Your request is now pending. You will be notified when this changes. Read
-    more about Toolkitties <a href="/help">here</a>.
+    more about Toolkitties <a href="#/help">here</a>.
   </p>
   <span>⏳</span>
 {:else if requestStatus == "rejected"}

--- a/src/routes/(unauthed)/request/+page.ts
+++ b/src/routes/(unauthed)/request/+page.ts
@@ -9,7 +9,7 @@ export const load: PageLoad = async () => {
 
   // if we already have access then go to the calendar
   if (accessStatus == "accepted") {
-    goto("/app/events");
+    goto("#/app/events");
   }
 
   return {

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,8 +1,3 @@
-// Tauri doesn't have a Node.js server to do proper SSR
-// so we will use adapter-static to prerender the app (SSG)
-// See: https://v2.tauri.app/start/frontend/sveltekit/ for more info
-// We are using Hash routing so we don't need to specify prerendering or ssr here.
-
 import type { LayoutLoad } from "./$types";
 import { calendars, identity } from "$lib/api";
 

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,8 +1,7 @@
 // Tauri doesn't have a Node.js server to do proper SSR
 // so we will use adapter-static to prerender the app (SSG)
 // See: https://v2.tauri.app/start/frontend/sveltekit/ for more info
-export const prerender = true;
-export const ssr = false;
+// We are using Hash routing so we don't need to specify prerendering or ssr here.
 
 import type { LayoutLoad } from "./$types";
 import { calendars, identity } from "$lib/api";

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -26,15 +26,15 @@
 
       if (accessStatus == "accepted") {
         // access is accepted, go to events
-        goto("/app/events");
+        goto("#/app/events");
         return;
       } else if (accessStatus == "pending") {
         // access status is pending, go to pending page
-        goto("/request");
+        goto("#/request");
         return;
       }
     }
-    goto("/join");
+    goto("#/join");
   }
 
   onMount(() => {

--- a/src/routes/app/+layout.svelte
+++ b/src/routes/app/+layout.svelte
@@ -21,27 +21,27 @@
   const menu: MenuItem[] = [
     {
       name: "Calendar",
-      url: "/app/events",
+      url: "#/app/events",
       icon: CalendarIcon,
     },
     {
       name: "Spaces",
-      url: "/app/spaces",
+      url: "#/app/spaces",
       icon: FootstepsIcon,
     },
     {
       name: "Resources",
-      url: "/app/resources",
+      url: "#/app/resources",
       icon: ChestIcon,
     },
     {
       name: "Dashboard",
-      url: "/app/dashboard",
+      url: "#/app/dashboard",
       icon: DashboardIcon,
     },
     {
       name: "Admin",
-      url: "/app/admin",
+      url: "#/app/admin",
       icon: ShareIcon,
     },
   ];
@@ -72,7 +72,7 @@
           <li>
             <a
               href={url}
-              class={page.url.pathname.includes(url) ? "active" : "not-active"}
+              class={page.url.hash.includes(url) ? "active" : "not-active"}
             >
               <Icon />
               <span class="sr-only">{name}</span>

--- a/src/routes/app/dashboard/+page.svelte
+++ b/src/routes/app/dashboard/+page.svelte
@@ -44,7 +44,10 @@
   <h3>my events & requests</h3>
   {#if $myEvents?.length > 0}
     {#each $myEvents as event (event.id)}
-      <a href={`/app/events/${event.id}`} class="p-2 border-black border block">
+      <a
+        href={`#/app/events/${event.id}`}
+        class="p-2 border-black border block"
+      >
         <h4>{event.name}</h4>
         <p>{event.startDate}</p>
         <p>{event.space ? event.space.name : "no space yet"}</p>

--- a/src/routes/app/events/+page.svelte
+++ b/src/routes/app/events/+page.svelte
@@ -9,11 +9,11 @@
 
 <CalendarSelector />
 <h1 class="font-pixel">{data.title}</h1>
-<a href="/app/calendars/create">Create Calendar</a>
+<a href="#/app/calendars/create">Create Calendar</a>
 {#if data.userRole === "admin"}
-  <a href="/app/calendars/edit">Edit Calendar</a>
+  <a href="#/app/calendars/edit">Edit Calendar</a>
 {/if}
-<a href="/app/events/create">Create event</a>
+<a href="#/app/events/create">Create event</a>
 
 {#each data.eventsList as event (event.id)}
   <EventRow {event} />
@@ -23,9 +23,9 @@
   <div class="fixed bottom-20 right-4 z-20 flex flex-col items-end space-y-2">
     {#if contributeButtonOpen}
       <div class="flex flex-col items-end space-y-2">
-        <a href="/app/spaces/create" class="bg-white">Space</a>
-        <a href="/app/resources/create" class="bg-white">Resource</a>
-        <a href="/app/events/create" class="bg-white">Event</a>
+        <a href="#/app/spaces/create" class="bg-white">Space</a>
+        <a href="#/app/resources/create" class="bg-white">Resource</a>
+        <a href="#/app/events/create" class="bg-white">Event</a>
       </div>
     {/if}
 

--- a/src/routes/app/events/EventForm.svelte
+++ b/src/routes/app/events/EventForm.svelte
@@ -228,7 +228,7 @@
       });
 
       toast.success("Event created!");
-      goto(`/app/events/${eventId}`);
+      goto(`#/app/events/${eventId}`);
     } catch (error) {
       console.error("Error creating event: ", error);
       toast.error("Error creating event!");
@@ -240,7 +240,7 @@
       await events.update(eventId, payload);
 
       toast.success("Event updated!");
-      goto(`/app/events/${eventId}`);
+      goto(`#/app/events/${eventId}`);
     } catch (error) {
       console.error("Error updating event: ", error);
       toast.error("Error updating event!");

--- a/src/routes/app/events/[id]/+page.svelte
+++ b/src/routes/app/events/[id]/+page.svelte
@@ -39,5 +39,5 @@
 {/if}
 <pre>{JSON.stringify(data.event)}</pre>
 {#if data.userRole == "admin"}
-  <a href="/app/events/{data.event!.id}/edit">Edit</a>
+  <a href="#/app/events/{data.event!.id}/edit">Edit</a>
 {/if}

--- a/src/routes/app/resources/+page.svelte
+++ b/src/routes/app/resources/+page.svelte
@@ -8,11 +8,11 @@
 <br />
 <br />
 <h1 class="font-pixel">Resources</h1>
-<a href="/app/resources/create">Create resource</a>
+<a href="#/app/resources/create">Create resource</a>
 
 {#each data.resourcesList as resource (resource.id)}
   <a
-    href={`/app/resources/${resource.id}`}
+    href={`#/app/resources/${resource.id}`}
     class="flex border-black border event-row"
   >
     <!-- <img

--- a/src/routes/app/resources/[id]/+page.svelte
+++ b/src/routes/app/resources/[id]/+page.svelte
@@ -29,5 +29,5 @@
 {/if}
 <pre>{JSON.stringify(data.resource)}</pre>
 {#if data.userRole == "admin"}
-  <a href="/app/resources/{data.resource!.id}/edit">Edit</a>
+  <a href="#/app/resources/{data.resource!.id}/edit">Edit</a>
 {/if}

--- a/src/routes/app/spaces/+page.svelte
+++ b/src/routes/app/spaces/+page.svelte
@@ -8,10 +8,10 @@
 <br />
 <br />
 <h1 class="font-pixel">Spaces</h1>
-<a href="/app/spaces/create">Create space</a>
+<a href="#/app/spaces/create">Create space</a>
 {#each data.spacesList as space (space.id)}
   <a
-    href={`/app/spaces/${space.id}`}
+    href={`#/app/spaces/${space.id}`}
     class="flex border-black border event-row"
   >
     <img

--- a/src/routes/app/spaces/SpaceForm.svelte
+++ b/src/routes/app/spaces/SpaceForm.svelte
@@ -43,7 +43,7 @@
     try {
       const spaceId = await spaces.create(activeCalendarId, payload);
       toast.success("Space created!");
-      goto(`/app/spaces/${spaceId}`);
+      goto(`#/app/spaces/${spaceId}`);
     } catch (error) {
       console.error("Error creating space: ", error);
       toast.error("Error creating space!");
@@ -54,7 +54,7 @@
     try {
       await spaces.update(resourceId, payload);
       toast.success("Space updated!");
-      goto(`/app/spaces/${data.id}`);
+      goto(`#/app/spaces/${data.id}`);
     } catch (error) {
       console.error("Error updating space: ", error);
       toast.error("Error updating space!");

--- a/src/routes/app/spaces/[id]/+page.svelte
+++ b/src/routes/app/spaces/[id]/+page.svelte
@@ -29,5 +29,5 @@
 {/if}
 <pre>{JSON.stringify(data.space)}</pre>
 {#if data.userRole == "admin"}
-  <a href="/app/spaces/{data.space!.id}/edit">Edit</a>
+  <a href="#/app/spaces/{data.space!.id}/edit">Edit</a>
 {/if}

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -10,6 +10,9 @@ const config = {
   kit: {
     adapter: adapter(),
     router: {
+      // Set router to type hash so we can build dynamic urls 
+      // where we don't know the ID of an entity at build time.
+      // This means all urls in the app to start with a #
       type: 'hash'
     }
   },

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -9,6 +9,9 @@ const config = {
   preprocess: vitePreprocess(),
   kit: {
     adapter: adapter(),
+    router: {
+      type: 'hash'
+    }
   },
 };
 


### PR DESCRIPTION
This PR sets sveltekit's router to type hash so we can build all routes even if they contain dynamic ids.

All routes in the app now start with hash, for example:
`/app/events`→` #/app/events`
`/app/events/123/edit`→` #/app/events/123/edit`

Closes #203 