### PR TITLE
Enriched requests

### DIFF
--- a/src/lib/api/access.ts
+++ b/src/lib/api/access.ts
@@ -22,7 +22,7 @@ import { promiseResult } from "$lib/promiseMap";
  */
 export async function getPending(activeCalendarId: Hash) {
   const accessRequests = await db.accessRequests
-    .where({ calendarId: activeCalendarId, status: 'pending' })
+    .where({ calendarId: activeCalendarId, status: "pending" })
     .toArray();
   return accessRequests;
 }

--- a/src/lib/components/BookingRequest.svelte
+++ b/src/lib/components/BookingRequest.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  let { request }: { request: BookingRequestEnriched } = $props();
+  import FootstepsIcon from "$lib/components/icons/FootstepsIcon.svelte";
+  import ChestIcon from "$lib/components/icons/ChestIcon.svelte";
+</script>
+
+<div
+  class="border border-black rounded p-2 flex justify-between w-full text-left"
+>
+  {#if request.resourceType === "resource"}
+    <div class="flex gap-2 items-center">
+      <ChestIcon size={22} />
+      <span
+        >{request.resource?.name ? request.resource?.name : "No name yet"}
+      </span>
+    </div>
+  {:else}
+    <div class="flex gap-2 items-center">
+      <FootstepsIcon size={22} />
+      <span>{request.space?.name ? request.space?.name : "No name yet"}</span>
+    </div>
+  {/if}
+  <span
+    class={`border border-black rounded px-2 ${
+      request.status === "accepted" ? "bg-green-light-fluro" : "bg-red-light"
+    }`}>{request.status}</span
+  >
+</div>

--- a/src/lib/components/Toasts.svelte
+++ b/src/lib/components/Toasts.svelte
@@ -47,4 +47,12 @@
   .toast.error {
     @apply bg-red-light;
   }
+
+  .toast.success {
+    @apply bg-green-light-fluro;
+  }
+
+  .toast.info {
+    @apply bg-pink-light;
+  }
 </style>

--- a/src/lib/components/dialog/BookingRequestDialog.svelte
+++ b/src/lib/components/dialog/BookingRequestDialog.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import * as AlertDialog from "./index";
   import { bookings } from "$lib/api";
+  import Date from "$lib/components/Date.svelte";
 
   let {
     request,
     open = $bindable(false),
-  }: { request: BookingRequest; open: boolean } = $props();
+  }: { request: BookingRequestEnriched; open: boolean } = $props();
 
   /**
    * Accept request for a booking
@@ -40,10 +41,17 @@
 
 <AlertDialog.Portal>
   <AlertDialog.Content>
-    <AlertDialog.Title>{request.resourceId} requested for:</AlertDialog.Title>
+    <AlertDialog.Title
+      >{request.resource?.name} requested for:</AlertDialog.Title
+    >
     <AlertDialog.Description>
-      <p>eventId: {request.eventId}</p>
-      <p>requester: {request.requester}</p>
+      <p>{request.event?.name}</p>
+      <p>
+        <Date date={request.timeSpan.start} />-<Date
+          date={request.timeSpan.end!}
+        />
+      </p>
+      <p>{request.space?.name}</p>
     </AlertDialog.Description>
     <AlertDialog.Action onclick={() => acceptRequest(request.id)}
       >accept</AlertDialog.Action

--- a/src/lib/toast.svelte.ts
+++ b/src/lib/toast.svelte.ts
@@ -79,8 +79,8 @@ class Toasts {
   /**
    * Show booking request toast to the user
    */
-  bookingRequest(data: BookingRequest) {
-    const message = "new booking request: " + data.id;
+  bookingRequest(data: BookingRequestEnriched) {
+    const message = "new booking request for " + data.resource?.name;
     const request: RequestEvent = {
       type: "booking_request",
       data,

--- a/src/lib/toast.svelte.ts
+++ b/src/lib/toast.svelte.ts
@@ -80,8 +80,10 @@ class Toasts {
    * Show booking request toast to the user
    */
   bookingRequest(data: BookingRequestEnriched) {
-    const name = data.resourceType === 'space' ? data.space?.name : data.resource?.name
-    const message = "new booking request for " + (name ? name : data.resourceId);
+    const name =
+      data.resourceType === "space" ? data.space?.name : data.resource?.name;
+    const message =
+      "new booking request for " + (name ? name : data.resourceId);
     const request: RequestEvent = {
       type: "booking_request",
       data,

--- a/src/lib/toast.svelte.ts
+++ b/src/lib/toast.svelte.ts
@@ -80,7 +80,8 @@ class Toasts {
    * Show booking request toast to the user
    */
   bookingRequest(data: BookingRequestEnriched) {
-    const message = "new booking request for " + data.resource?.name;
+    const name = data.resourceType === 'space' ? data.space?.name : data.resource?.name
+    const message = "new booking request for " + (name ? name : data.resourceId);
     const request: RequestEvent = {
       type: "booking_request",
       data,

--- a/src/routes/app/dashboard/RequestDialog.svelte
+++ b/src/routes/app/dashboard/RequestDialog.svelte
@@ -2,14 +2,14 @@
   import BookingRequestDialog from "$lib/components/dialog/BookingRequestDialog.svelte";
   import * as AlertDialog from "$lib/components/dialog/index";
 
-  let { request }: { request: BookingRequest } = $props();
+  let { request }: { request: BookingRequestEnriched } = $props();
 
   let open = $state(false);
 </script>
 
 <AlertDialog.Root bind:open>
-  <AlertDialog.Trigger class="button">
-    <p>{request.id}</p>
+  <AlertDialog.Trigger class="button flex justify-between w-full text-left">
+    <p>{request.resource?.name}</p>
     <span>Pending</span>
     <BookingRequestDialog {request} bind:open />
   </AlertDialog.Trigger>

--- a/src/routes/app/dashboard/RequestDialog.svelte
+++ b/src/routes/app/dashboard/RequestDialog.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import BookingRequestDialog from "$lib/components/dialog/BookingRequestDialog.svelte";
   import * as AlertDialog from "$lib/components/dialog/index";
+  import BookingRequest from "$lib/components/BookingRequest.svelte";
 
   let { request }: { request: BookingRequestEnriched } = $props();
 
@@ -8,9 +9,8 @@
 </script>
 
 <AlertDialog.Root bind:open>
-  <AlertDialog.Trigger class="button flex justify-between w-full text-left">
-    <p>{request.resource?.name}</p>
-    <span>Pending</span>
+  <AlertDialog.Trigger class="w-full">
+    <BookingRequest {request} />
     <BookingRequestDialog {request} bind:open />
   </AlertDialog.Trigger>
 </AlertDialog.Root>

--- a/src/routes/app/events/[id]/+page.svelte
+++ b/src/routes/app/events/[id]/+page.svelte
@@ -5,6 +5,8 @@
   import { bookings } from "$lib/api";
   import Links from "$lib/components/Links.svelte";
   import Date from "$lib/components/Date.svelte";
+  import FootstepsIcon from "$lib/components/icons/FootstepsIcon.svelte";
+  import ChestIcon from "$lib/components/icons/ChestIcon.svelte";
 
   let { data }: PageProps = $props();
 
@@ -33,18 +35,32 @@
     {/if}
   </div>
 
-  {#if data.userRole === "admin" && $upcomingBookings?.length > 0}
+  {#if (data.userRole === "admin" || data.publicKey == data.event.ownerId) && $upcomingBookings?.length > 0}
     <section>
       <h3>Requests</h3>
       {#each $upcomingBookings as booking (booking.id)}
         <div
           class="border border-black p-2 flex justify-between w-full text-left"
         >
-          <span
-            >{booking.resource?.name
-              ? booking.resource?.name
-              : "No name yet"}</span
-          >
+          {#if booking.resourceType === "resource"}
+            <div class="flex gap-2 items-center">
+              <ChestIcon size={22} />
+              <span
+                >{booking.resource?.name
+                  ? booking.resource?.name
+                  : "No name yet"}
+              </span>
+            </div>
+          {:else}
+            <div class="flex gap-2 items-center">
+              <FootstepsIcon size={22} />
+              <span
+                >{booking.space?.name
+                  ? booking.space?.name
+                  : "No name yet"}</span
+              >
+            </div>
+          {/if}
           <span>{booking.status}</span>
         </div>
       {/each}

--- a/src/routes/app/events/[id]/+page.svelte
+++ b/src/routes/app/events/[id]/+page.svelte
@@ -5,8 +5,7 @@
   import { bookings } from "$lib/api";
   import Links from "$lib/components/Links.svelte";
   import Date from "$lib/components/Date.svelte";
-  import FootstepsIcon from "$lib/components/icons/FootstepsIcon.svelte";
-  import ChestIcon from "$lib/components/icons/ChestIcon.svelte";
+  import BookingRequest from "$lib/components/BookingRequest.svelte";
 
   let { data }: PageProps = $props();
 
@@ -39,30 +38,7 @@
     <section>
       <h3>Requests</h3>
       {#each $upcomingBookings as booking (booking.id)}
-        <div
-          class="border border-black p-2 flex justify-between w-full text-left"
-        >
-          {#if booking.resourceType === "resource"}
-            <div class="flex gap-2 items-center">
-              <ChestIcon size={22} />
-              <span
-                >{booking.resource?.name
-                  ? booking.resource?.name
-                  : "No name yet"}
-              </span>
-            </div>
-          {:else}
-            <div class="flex gap-2 items-center">
-              <FootstepsIcon size={22} />
-              <span
-                >{booking.space?.name
-                  ? booking.space?.name
-                  : "No name yet"}</span
-              >
-            </div>
-          {/if}
-          <span>{booking.status}</span>
-        </div>
+        <BookingRequest request={booking} />
       {/each}
     </section>
   {/if}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,10 +30,14 @@ export default {
         },
         black: '#020202',
         pink: {
-          hot: '#FF00E5'
+          hot: '#FF00E5',
+          light: '#FFDFFA',
         },
         blue: {
           light: '#baceff'
+        },
+        green: {
+          'light-fluro': '#B4FFB2',
         }
       },
       fontFamily: {


### PR DESCRIPTION
This PR adds enriched info to request and request toasts so they now correctly display:
- Name of resource/space
- Event of booking request
- Date/time of event of booking request.

This also fixed a bug with `access.findPending()` so it now only returns pending access requests.