### PR TITLE
Fix pending access requests API method

### DIFF
--- a/src/lib/api/access.ts
+++ b/src/lib/api/access.ts
@@ -22,9 +22,19 @@ import { promiseResult } from "$lib/promiseMap";
  */
 export async function getPending(activeCalendarId: Hash) {
   const accessRequests = await db.accessRequests
-    .where({ calendarId: activeCalendarId, status: "pending" })
+    .where({ calendarId: activeCalendarId })
     .toArray();
-  return accessRequests;
+
+  const pendingRequests = await Promise.all(
+    accessRequests.map(async (request) => {
+      const status = await checkStatus(request.from, activeCalendarId);
+      return { request, status };
+    })
+  );
+
+  return pendingRequests
+    .filter(({ status }) => status === 'pending')
+    .map(({ request }) => request);
 }
 
 export async function findRequestByid(id: Hash) {

--- a/src/lib/api/access.ts
+++ b/src/lib/api/access.ts
@@ -29,11 +29,11 @@ export async function getPending(activeCalendarId: Hash) {
     accessRequests.map(async (request) => {
       const status = await checkStatus(request.from, activeCalendarId);
       return { request, status };
-    })
+    }),
   );
 
   return pendingRequests
-    .filter(({ status }) => status === 'pending')
+    .filter(({ status }) => status === "pending")
     .map(({ request }) => request);
 }
 


### PR DESCRIPTION
This PR fixes `access.getPending` API method to correctly return only pending access requests using the new `checkAccess` method internally.