### PR TITLE
Fixes: processing pending messages and inbox sync

### DIFF
--- a/src/lib/api/access.ts
+++ b/src/lib/api/access.ts
@@ -334,8 +334,8 @@ async function onCalendarAccessAccepted(
   }
 
   // Add the new author to the calendar topics.
-  await topics.addAuthorToCalendar(meta.author, meta.stream);
-  await topics.addAuthorToInbox(meta.author, meta.stream);
+  await topics.addAuthorToCalendar(request.from, meta.stream);
+  await topics.addAuthorToInbox(request.from, meta.stream);
 
   // If this is our own access request then also add ourselves and the calendar owner to the
   // topic may as we won't have done this before.

--- a/src/lib/api/access.ts
+++ b/src/lib/api/access.ts
@@ -307,19 +307,17 @@ async function onCalendarAccessRequested(
   if (accessStatus == "pending" && (amOwner || amAdmin)) {
     toast.accessRequest(accessRequest);
   }
-
-  if (accessStatus == "accepted") {
-    // Create a new user.
-    if (!(await users.get(calendarId, meta.author))) {
-      await users.create(calendarId, meta.author, data.name);
-    }
-  }
 }
 
 async function onCalendarAccessAccepted(
   meta: StreamMessageMeta,
   data: CalendarAccessAccepted["data"],
 ) {
+  const request = await db.accessRequests.get(data.requestId);
+  if (!request) {
+    throw Error("access request not found");
+  }
+
   const calendarId = meta.stream.id;
   await db.accessResponses.add({
     id: meta.operationId,
@@ -329,34 +327,24 @@ async function onCalendarAccessAccepted(
     answer: "accept",
   });
 
-  const request = await db.accessRequests.get(data.requestId);
-  if (!request) {
-    return;
+  // Create a new user.
+  const user = await users.get(calendarId, request.from);
+  if (!user) {
+    await users.create(calendarId, request.from, request.name);
   }
 
-  const accessStatus = await checkStatus(request.from, calendarId);
+  // Add the new author to the calendar topics.
+  await topics.addAuthorToCalendar(meta.author, meta.stream);
+  await topics.addAuthorToInbox(meta.author, meta.stream);
 
-  // Process new calendar author if access was accepted.
-  if (accessStatus == "accepted") {
-    // Create a new user.
-    const user = await users.get(calendarId, request.from);
-    if (!user) {
-      await users.create(calendarId, request.from, request.name);
-    }
-
-    // Add the new author to the calendar topics.
-    await topics.addAuthorToCalendar(meta.author, meta.stream);
-    await topics.addAuthorToInbox(meta.author, meta.stream);
-
-    // If this is our own access request then also add ourselves and the calendar owner to the
-    // topic may as we won't have done this before.
-    const myPublicKey = await identity.publicKey();
-    if (myPublicKey == request.from) {
-      await topics.subscribeToCalendar(meta.stream.id);
-      await topics.addAuthorToCalendar(myPublicKey, meta.stream);
-      await topics.addAuthorToCalendar(meta.stream.owner, meta.stream);
-      await topics.addAuthorToInbox(meta.stream.owner, meta.stream);
-    }
+  // If this is our own access request then also add ourselves and the calendar owner to the
+  // topic may as we won't have done this before.
+  const myPublicKey = await identity.publicKey();
+  if (myPublicKey == request.from) {
+    await topics.addAuthorToCalendar(myPublicKey, meta.stream);
+    await topics.addAuthorToCalendar(meta.stream.owner, meta.stream);
+    await topics.addAuthorToInbox(meta.stream.owner, meta.stream);
+    await topics.subscribeToCalendar(meta.stream.id);
   }
 }
 

--- a/src/lib/api/calendars.ts
+++ b/src/lib/api/calendars.ts
@@ -183,7 +183,7 @@ async function onCalendarCreated(
   const myPublicKey = await identity.publicKey();
 
   // Add the calendar creator user to our database and make them admin.
-  const user = await users.get(meta.stream.id, myPublicKey);
+  const user = await users.get(meta.stream.id, meta.stream.owner);
   if (!user) {
     await users.create(meta.stream.id, meta.stream.owner, userName, "admin");
   }

--- a/src/lib/api/inviteCodes.ts
+++ b/src/lib/api/inviteCodes.ts
@@ -130,13 +130,13 @@ async function onResponse(response: ResolveInviteCodeResponse) {
     // don't add the name to the database yet, we wait for the "calendar_created" event for this.
   });
 
-  // Subscribe to the calendar inbox topic.
-  await topics.subscribeToInbox(stream.id);
-
   // Add ourselves and the calendar owner to the inbox topic log map.
   const myPublicKey = await identity.publicKey();
   await topics.addAuthorToInbox(myPublicKey, stream);
   await topics.addAuthorToInbox(stream.owner, stream);
+
+  // Subscribe to the calendar inbox topic.
+  await topics.subscribeToInbox(stream.id);
 
   // Set this calendar as the active calendar.
   await calendars.setActiveCalendar(stream.id);

--- a/src/lib/api/publish.ts
+++ b/src/lib/api/publish.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { db } from "$lib/db";
+import { publish } from ".";
 
 export const CALENDAR_LOG_PATH: LogPath = "calendar";
 export const CALENDAR_INBOX_LOG_PATH: LogPath = "calendar/inbox";
@@ -55,6 +56,7 @@ export async function toInbox(
     streamArgs: {
       rootHash: calendar.stream.rootHash,
       owner: calendar.stream.owner,
+      logPath: publish.CALENDAR_LOG_PATH,
     },
     logPath: CALENDAR_INBOX_LOG_PATH,
     topic: `${CALENDAR_INBOX_TOPIC_PREFIX}/${calendarId}`,

--- a/src/lib/channel.ts
+++ b/src/lib/channel.ts
@@ -1,5 +1,5 @@
 import { invoke, Channel } from "@tauri-apps/api/core";
-import { processMessage } from "$lib/processor";
+import { pendingQueue, processMessage } from "$lib/processor";
 
 export async function init() {
   // Create the stream channel to be passed to backend and add an `onMessage`
@@ -7,6 +7,12 @@ export async function init() {
   // backend to here.
   const channel = new Channel<ChannelMessage>();
   channel.onmessage = processMessage;
+
+  setInterval(async () => {
+    for (const [, message] of pendingQueue) {
+      await processMessage(message);
+    }
+  }, 100);
 
   // The start command must be called on app startup otherwise running the node
   // on the backend is blocked. This is because we need the stream channel to

--- a/src/lib/channel.ts
+++ b/src/lib/channel.ts
@@ -8,11 +8,14 @@ export async function init() {
   const channel = new Channel<ChannelMessage>();
   channel.onmessage = processMessage;
 
+  // @TODO: is this there a better place to be starting this interval?
+  //
+  // Attempt to process any messages in the pending queue every 200ms.
   setInterval(async () => {
     for (const [, message] of pendingQueue) {
       await processMessage(message);
     }
-  }, 100);
+  }, 200);
 
   // The start command must be called on app startup otherwise running the node
   // on the backend is blocked. This is because we need the stream channel to

--- a/src/lib/processor.ts
+++ b/src/lib/processor.ts
@@ -15,6 +15,7 @@ import {
 } from "$lib/api";
 import { rejectPromise, resolvePromise } from "$lib/promiseMap";
 
+export const pendingQueue: Map<Hash, ApplicationMessage> = new Map();
 const peers: Set<PublicKey> = new Set();
 
 // @TODO: update docs for application agnostic backend.
@@ -163,8 +164,12 @@ async function onApplicationMessage(message: ApplicationMessage) {
     // then error here. Additionally we want to trigger a replay if messages which may have
     // dependants arrives, eg. an `event_created` message should trigger a replay in case there are
     // waiting event_updated events.
-    await dependencies.process(message);
-
+    try {
+      await dependencies.process(message);
+    } catch {
+      pendingQueue.set(message.meta.operationId, message);
+      return;
+    }
     // **Auth**
     //
     // Confirm that the author has been given “read” access to the calendar with a
@@ -195,6 +200,7 @@ async function onApplicationMessage(message: ApplicationMessage) {
 
     // Acknowledge that we have received and processed this operation.
     await invoke("ack", { operationId: message.meta.operationId });
+    pendingQueue.delete(message.meta.operationId);
   } catch (err) {
     console.error(`failed processing application event: ${err}`, message);
     const myPublicKey = await identity.publicKey();

--- a/src/lib/processor.ts
+++ b/src/lib/processor.ts
@@ -166,7 +166,8 @@ async function onApplicationMessage(message: ApplicationMessage) {
     // waiting event_updated events.
     try {
       await dependencies.process(message);
-    } catch {
+    } catch (e) {
+      console.error("missing dependency for message: ", e);
       pendingQueue.set(message.meta.operationId, message);
       return;
     }


### PR DESCRIPTION
This PR fixes two semi-related issues which were causing issues with syncing peers inboxes and processing messages with missing dependencies.

- fix conditional checks which were using wrong public key arguments
- add access requester public key to topic map
- keep pending messages in a map and re-attempt process on interval rather than triggering replays 