### PR TITLE
Bugfix builds for production - URL query params for dynamic routes

### DIFF
--- a/src/lib/components/CalendarForm.svelte
+++ b/src/lib/components/CalendarForm.svelte
@@ -41,7 +41,7 @@
       // Reload data all data in the app as we changed to a new calendar.
       await invalidateAll();
       // TODO: Automatically reload app data when active calendar changes.
-      goto(`#/app/events`);
+      goto(`/app/events`);
     } catch (error) {
       console.error("Error creating calendar: ", error);
       toast.error("Error creating calendar!");
@@ -55,7 +55,7 @@
     try {
       await calendars.update(calendarId, payload);
       toast.success("Calendar updated!");
-      goto(`#/app/events`);
+      goto(`/app/events`);
     } catch (error) {
       console.error("Error updating calendar: ", error);
       toast.error("Error updating calendar!");

--- a/src/lib/components/CalendarSelector.svelte
+++ b/src/lib/components/CalendarSelector.svelte
@@ -49,8 +49,8 @@
               label={calendar.name}>{calendar.name}</Select.Item
             >
           {/each}
-          <a href="#/join">Join Calendar</a>
-          <a href="#/create">+ Create new calendar</a>
+          <a href="/join">Join Calendar</a>
+          <a href="/create">+ Create new calendar</a>
         </Select.Viewport>
       </Select.Content>
     </Select.Portal>

--- a/src/lib/components/Contribute.svelte
+++ b/src/lib/components/Contribute.svelte
@@ -6,9 +6,9 @@
   <div class="fixed bottom-20 right-4 z-20 flex flex-col items-end space-y-2">
     {#if contributeButtonOpen}
       <div class="flex flex-col items-end space-y-2">
-        <a href="#/app/spaces/create" class="bg-white">Space</a>
-        <a href="#/app/resources/create" class="bg-white">Resource</a>
-        <a href="#/app/events/create" class="bg-white">Event</a>
+        <a href="/app/spaces/create" class="bg-white">Space</a>
+        <a href="/app/resources/create" class="bg-white">Resource</a>
+        <a href="/app/events/create" class="bg-white">Event</a>
       </div>
     {/if}
 

--- a/src/lib/components/EventRow.svelte
+++ b/src/lib/components/EventRow.svelte
@@ -10,7 +10,10 @@
   // let tagColours = ["bg-yellow-light", "bg-fluro-green-light", "bg-red-light"];
 </script>
 
-<a href={`#/app/events/${event.id}`} class="flex border-black border event-row">
+<a
+  href={`/app/events/view?id=${event.id}`}
+  class="flex border-black border event-row"
+>
   {#if event.images.length > 0}
     <img
       src={`blobstore://${event.images[0]}`}

--- a/src/lib/components/UpcomingBookings.svelte
+++ b/src/lib/components/UpcomingBookings.svelte
@@ -16,7 +16,7 @@
     <h3>Upcoming bookings</h3>
     {#each $upcomingBookings as booking (booking.id)}
       <a
-        href={`#/app/events/${booking.eventId}`}
+        href={`/app/events/view?id=${booking.eventId}`}
         class="block border border-black p-2 w-full text-left"
       >
         <p>{booking.event?.name}</p>

--- a/src/lib/components/dialog/Delete.svelte
+++ b/src/lib/components/dialog/Delete.svelte
@@ -37,7 +37,7 @@
       toast.success(`Successfully deleted ${name}`);
       // close the dialog
       open = false;
-      goto(`#/app/${type}s`);
+      goto(`/app/${type}s`);
     } catch (error) {
       open = false;
       toast.error(`Failed to delete ${name}`);

--- a/src/routes/(unauthed)/join/+page.svelte
+++ b/src/routes/(unauthed)/join/+page.svelte
@@ -33,7 +33,7 @@
     // reload data so we get the latest active calendar
     // TODO: move active calendar to reactive state so we don't need to do this.
     await invalidateAll();
-    goto(`#/request`);
+    goto(`/request`);
   }
 </script>
 
@@ -87,7 +87,7 @@
 </div>
 
 <a
-  href="#/create"
+  href="/create"
   class="border border-black rounded p-4 text-center"
   type="submit">Create</a
 >

--- a/src/routes/(unauthed)/request/+page.svelte
+++ b/src/routes/(unauthed)/request/+page.svelte
@@ -19,7 +19,7 @@
 
     if (accessStatus == "accepted") {
       toast.success("access accepted!");
-      goto("#/app/events");
+      goto("/app/events");
     } else if (accessStatus == "rejected") {
       toast.error("access rejected!");
       goto("/");

--- a/src/routes/(unauthed)/request/+page.ts
+++ b/src/routes/(unauthed)/request/+page.ts
@@ -9,7 +9,7 @@ export const load: PageLoad = async () => {
 
   // if we already have access then go to the calendar
   if (accessStatus == "accepted") {
-    goto("#/app/events");
+    goto("/app/events");
   }
 
   return {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -40,7 +40,7 @@
 
         if (import.meta.env.PROD) {
           // Delete frontend database for now as there is no persistence on the backend yet.
-          // Everytime we launch app in prod we get a new publicKey and all events.
+          // AS without persistence, everytime we launch app in prod we get a new publicKey and all events.
           await db.delete({ disableAutoOpen: false });
         }
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -38,6 +38,12 @@
           console.info("finished seeding db");
         }
 
+        if (import.meta.env.PROD) {
+          // Delete frontend database for now as there is no persistence on the backend yet.
+          // Everytime we get launch app in prod we get a new publicKey and all events.
+          await db.delete({ disableAutoOpen: false });
+        }
+
         await topics.subscribeEphemeral(INVITE_TOPIC);
 
         // @TODO(sam): we have no persistence layer at the moment so we don't need to subscribe to

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -40,7 +40,7 @@
 
         if (import.meta.env.PROD) {
           // Delete frontend database for now as there is no persistence on the backend yet.
-          // Everytime we get launch app in prod we get a new publicKey and all events.
+          // Everytime we launch app in prod we get a new publicKey and all events.
           await db.delete({ disableAutoOpen: false });
         }
 

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,4 +1,3 @@
-
 export const prerender = true;
 export const ssr = false;
 

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,3 +1,6 @@
+// Tauri doesn't have a Node.js server to do proper SSR
+// so we will use adapter-static to prerender the app (SSG)
+// See: https://v2.tauri.app/start/frontend/sveltekit/ for more info
 export const prerender = true;
 export const ssr = false;
 

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,3 +1,7 @@
+
+export const prerender = true;
+export const ssr = false;
+
 import type { LayoutLoad } from "./$types";
 import { calendars, identity } from "$lib/api";
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,15 +13,15 @@
 
       if (accessStatus == "accepted") {
         // access is accepted, go to events
-        goto("#/app/events");
+        goto("/app/events");
         return;
       } else if (accessStatus == "pending") {
         // access status is pending, go to pending page
-        goto("#/request");
+        goto("/request");
         return;
       }
     }
-    goto("#/join");
+    goto("/join");
   }
 
   // TODO: Run check access once we have successfully subscribed to channels (currently in +layout.svelte)

--- a/src/routes/app/+layout.svelte
+++ b/src/routes/app/+layout.svelte
@@ -71,7 +71,7 @@
         <li>
           <a
             href={url}
-            class={page.url.hash.includes(url) ? "active" : "not-active"}
+            class={page.url.pathname.includes(url) ? "active" : "not-active"}
           >
             <Icon />
             <span class="sr-only">{name}</span>

--- a/src/routes/app/+layout.svelte
+++ b/src/routes/app/+layout.svelte
@@ -21,27 +21,27 @@
   const menu: MenuItem[] = [
     {
       name: "Calendar",
-      url: "#/app/events",
+      url: "/app/events",
       icon: CalendarIcon,
     },
     {
       name: "Spaces",
-      url: "#/app/spaces",
+      url: "/app/spaces",
       icon: FootstepsIcon,
     },
     {
       name: "Resources",
-      url: "#/app/resources",
+      url: "/app/resources",
       icon: ChestIcon,
     },
     {
       name: "Dashboard",
-      url: "#/app/dashboard",
+      url: "/app/dashboard",
       icon: DashboardIcon,
     },
     {
       name: "Admin",
-      url: "#/app/admin",
+      url: "/app/admin",
       icon: ShareIcon,
     },
   ];

--- a/src/routes/app/+layout.ts
+++ b/src/routes/app/+layout.ts
@@ -14,7 +14,7 @@ export const load: LayoutLoad = async ({ parent }) => {
 
   if (accessStatus == "pending") {
     // access status is pending, go to pending page
-    goto("#/request");
+    goto("/request");
     return;
   }
 

--- a/src/routes/app/dashboard/+page.svelte
+++ b/src/routes/app/dashboard/+page.svelte
@@ -46,7 +46,7 @@
   {#if $myEvents?.length > 0}
     {#each $myEvents as event (event.id)}
       <a
-        href={`#/app/events/${event.id}`}
+        href={`/app/events/view?=${event.id}`}
         class="p-2 border-black border block"
       >
         <h4>{event.name}</h4>
@@ -65,7 +65,7 @@
       </a>
     {/each}
     <a
-      href="#/app/events/create"
+      href="/app/events/create"
       class="rounded-full border-black border p-2 inline-block"
     >
       <PlusIcon size={10} />
@@ -80,7 +80,7 @@
   {#if $mySpaces?.length > 0}
     {#each $mySpaces as space (space.id)}
       <a
-        href={`#/app/spaces/${space.id}`}
+        href={`/app/spaces/view?=${space.id}`}
         class="p-2 border-black border justify-between flex"
       >
         <p>{space.name}</p>
@@ -93,7 +93,7 @@
     <p>you don't have any spaces yet</p>
   {/if}
   <a
-    href="#/app/spaces/create"
+    href="/app/spaces/create"
     class="rounded-full border-black border p-2 inline-block"
   >
     <PlusIcon size={10} />
@@ -105,7 +105,7 @@
   {#if $myResources?.length > 0}
     {#each $myResources as resource (resource.id)}
       <a
-        href={`#/app/resources/${resource.id}`}
+        href={`/app/resources/view?id=${resource.id}`}
         class="p-2 border-black border justify-between flex"
       >
         <p>{resource.name}</p>
@@ -118,7 +118,7 @@
     <p>you don't have any resources yet</p>
   {/if}
   <a
-    href="#/app/resources/create"
+    href="/app/resources/create"
     class="rounded-full border-black border p-2 inline-block"
   >
     <PlusIcon size={10} />

--- a/src/routes/app/events/+page.svelte
+++ b/src/routes/app/events/+page.svelte
@@ -86,7 +86,7 @@
   {/each}
 {:else}
   <p>no events yet, please create one.</p>
-  <a href="#/app/events/create" class="button inline-block">create event</a>
+  <a href="/app/events/create" class="button inline-block">create event</a>
 {/if}
 
 <Contribute />

--- a/src/routes/app/events/EventForm.svelte
+++ b/src/routes/app/events/EventForm.svelte
@@ -255,7 +255,7 @@
       });
 
       toast.success("Event created!");
-      goto(`#/app/events/${eventId}`);
+      goto(`/app/events/${eventId}`);
     } catch (error) {
       console.error("Error creating event: ", error);
       toast.error("Error creating event!");
@@ -267,7 +267,7 @@
       await events.update(eventId, payload);
 
       toast.success("Event updated!");
-      goto(`#/app/events/${eventId}`);
+      goto(`/app/events/${eventId}`);
     } catch (error) {
       console.error("Error updating event: ", error);
       toast.error("Error updating event!");
@@ -280,8 +280,7 @@
     No available spaces have been contributed. Create at least one space before
     creating an event.
   </p>
-  <a href="#/app/spaces/create" class="button mt-4 inline-block">Create space</a
-  >
+  <a href="/app/spaces/create" class="button mt-4 inline-block">Create space</a>
 {:else}
   <SuperDebug data={{ $form, $errors }} />
   <form method="POST" use:enhance>

--- a/src/routes/app/events/edit/+page.svelte
+++ b/src/routes/app/events/edit/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import EventForm from "../../EventForm.svelte";
+  import EventForm from "../EventForm.svelte";
   import type { PageProps } from "./$types";
   import Delete from "$lib/components/dialog/Delete.svelte";
 

--- a/src/routes/app/events/edit/+page.ts
+++ b/src/routes/app/events/edit/+page.ts
@@ -7,10 +7,16 @@ import { zod } from "sveltekit-superforms/adapters";
 import { db } from "$lib/db";
 import { TimeSpanClass } from "$lib/timeSpan";
 
-export const load: PageLoad = async ({ params, parent }) => {
-  const eventId = params.id;
-  const event = await events.findById(eventId);
+export const load: PageLoad = async ({ parent, url }) => {
 
+  const eventId = url.searchParams.get('id');
+  if (!eventId) {
+    error(404, {
+      message: "Event not found",
+    });
+  }
+
+  const event = await events.findById(eventId);
   if (!event || !event.id) {
     error(404, {
       message: "Event not found",

--- a/src/routes/app/events/edit/+page.ts
+++ b/src/routes/app/events/edit/+page.ts
@@ -8,8 +8,7 @@ import { db } from "$lib/db";
 import { TimeSpanClass } from "$lib/timeSpan";
 
 export const load: PageLoad = async ({ parent, url }) => {
-
-  const eventId = url.searchParams.get('id');
+  const eventId = url.searchParams.get("id");
   if (!eventId) {
     error(404, {
       message: "Event not found",

--- a/src/routes/app/events/view/+page.svelte
+++ b/src/routes/app/events/view/+page.svelte
@@ -49,7 +49,7 @@
         <DateRange startDate={$event.startDate} endDate={$event.endDate} />
       </p>
       {#if $event.space}
-        <a href={`#/spaces/${$event.space.id}`}>{$event.space.name}</a>
+        <a href={`/spaces/view?id=${$event.space.id}`}>{$event.space.name}</a>
       {/if}
     </div>
 
@@ -69,7 +69,7 @@
     <ImageGallery images={$event.images} />
 
     {#if data.userRole == "admin" || amOwner}
-      <a class="button" href="#/app/events/{$event!.id}/edit">Edit</a>
+      <a class="button" href="/app/events/edit?id={$event!.id}">Edit</a>
     {/if}
 
     <pre>{JSON.stringify($event, null, 2)}</pre>

--- a/src/routes/app/events/view/+page.ts
+++ b/src/routes/app/events/view/+page.ts
@@ -1,12 +1,19 @@
 import type { PageLoad } from "./$types";
 import { users } from "$lib/api";
+import { error } from "@sveltejs/kit";
 
-export const load: PageLoad = async ({ params, parent }) => {
+export const load: PageLoad = async ({ url, parent }) => {
+  const eventId = url.searchParams.get('id');
+  if (!eventId) {
+    error(404, {
+      message: "Event not found",
+    });
+  }
+
   const parentData = await parent();
   const { activeCalendarId, publicKey } = parentData;
   const user = await users.get(activeCalendarId!, publicKey);
   const userRole = user!.role;
-  const eventId = params.id;
 
   return { title: "events", eventId, userRole };
 };

--- a/src/routes/app/events/view/+page.ts
+++ b/src/routes/app/events/view/+page.ts
@@ -3,7 +3,7 @@ import { users } from "$lib/api";
 import { error } from "@sveltejs/kit";
 
 export const load: PageLoad = async ({ url, parent }) => {
-  const eventId = url.searchParams.get('id');
+  const eventId = url.searchParams.get("id");
   if (!eventId) {
     error(404, {
       message: "Event not found",

--- a/src/routes/app/resources/+page.svelte
+++ b/src/routes/app/resources/+page.svelte
@@ -26,7 +26,7 @@
 {#if $resourcesList && $resourcesList.length > 0}
   {#each $resourcesList as resource (resource.id)}
     <a
-      href={`#/app/resources/${resource.id}`}
+      href={`/app/resources/view?id=${resource.id}`}
       class="flex border-black border event-row"
     >
       {#if resource.images.length > 0}
@@ -50,7 +50,7 @@
   {/each}
 {:else}
   <p>no resources yet, please create one.</p>
-  <a href="#/app/events/create" class="button inline-block">create resource</a>
+  <a href="/app/events/create" class="button inline-block">create resource</a>
 {/if}
 
 <Contribute />

--- a/src/routes/app/resources/ResourceForm.svelte
+++ b/src/routes/app/resources/ResourceForm.svelte
@@ -55,7 +55,7 @@
         payload,
       );
       toast.success("Resource created!");
-      goto(`#/app/resources/${resourceId}`);
+      goto(`/app/resources/${resourceId}`);
     } catch (error) {
       toast.error("Error creating resource!");
       console.error("Error creating resource:", error);
@@ -69,7 +69,7 @@
     try {
       await resources.update(resourceId, payload);
       toast.success("Resource updated!");
-      goto(`#/app/resources/${resourceId}`);
+      goto(`/app/resources/${resourceId}`);
     } catch (error) {
       toast.error("Error updating resource!");
       console.error("Error updating resource:", error);

--- a/src/routes/app/resources/edit/+page.svelte
+++ b/src/routes/app/resources/edit/+page.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
-  import SpaceForm from "../../SpaceForm.svelte";
+  import ResourceForm from "../ResourceForm.svelte";
   import type { PageProps } from "./$types";
   import Delete from "$lib/components/dialog/Delete.svelte";
 
   let { data }: PageProps = $props();
 </script>
 
-<SpaceForm
+<ResourceForm
   data={data.form}
-  activeCalendarId={data.activeCalendarId}
+  activeCalendarId={data.activeCalendarId!}
   calendarDates={data.calendarDates}
 />
-{#if data.userRole == "admin"}
-  <Delete id={data.form.data.id!} name={data.form.data.name} type="space" />
+{#if data.userRole === "admin"}
+  <Delete id={data.form.data.id!} name={data.form.data.name} type="resource" />
 {/if}

--- a/src/routes/app/resources/edit/+page.ts
+++ b/src/routes/app/resources/edit/+page.ts
@@ -6,8 +6,7 @@ import { zod } from "sveltekit-superforms/adapters";
 import { resourceSchema } from "$lib/schemas";
 
 export const load: PageLoad = async ({ url, parent }) => {
-
-  const resourceId = url.searchParams.get('id');
+  const resourceId = url.searchParams.get("id");
   if (!resourceId) {
     error(404, {
       message: "Resource not found",

--- a/src/routes/app/resources/edit/+page.ts
+++ b/src/routes/app/resources/edit/+page.ts
@@ -5,10 +5,16 @@ import { superValidate } from "sveltekit-superforms";
 import { zod } from "sveltekit-superforms/adapters";
 import { resourceSchema } from "$lib/schemas";
 
-export const load: PageLoad = async ({ params, parent }) => {
-  const resourceId = params.id;
-  const resource = await resources.findById(resourceId);
+export const load: PageLoad = async ({ url, parent }) => {
 
+  const resourceId = url.searchParams.get('id');
+  if (!resourceId) {
+    error(404, {
+      message: "Resource not found",
+    });
+  }
+
+  const resource = await resources.findById(resourceId);
   if (!resource || !resource.id) {
     error(404, {
       message: "Resource not found",

--- a/src/routes/app/resources/view/+page.svelte
+++ b/src/routes/app/resources/view/+page.svelte
@@ -63,7 +63,7 @@
     {/if}
 
     {#if data.userRole == "admin" || amOwner}
-      <a class="button" href="#/app/resources/{$resource.id}/edit">Edit</a>
+      <a class="button" href="/app/resources/edit?id={$resource.id}">Edit</a>
     {/if}
 
     <ImageGallery images={$resource.images} />

--- a/src/routes/app/resources/view/+page.ts
+++ b/src/routes/app/resources/view/+page.ts
@@ -1,8 +1,16 @@
 import type { PageLoad } from "./$types";
 import { users } from "$lib/api";
+import { error } from "@sveltejs/kit";
 
-export const load: PageLoad = async ({ params, parent }) => {
-  const resourceId = params.id;
+export const load: PageLoad = async ({ url, parent }) => {
+
+  const resourceId = url.searchParams.get('id');
+  if (resourceId) {
+    error(404, {
+      message: "Resource not found",
+    });
+  }
+
   const parentData = await parent();
   const { activeCalendarId, publicKey } = parentData;
   const user = await users.get(activeCalendarId!, publicKey);

--- a/src/routes/app/resources/view/+page.ts
+++ b/src/routes/app/resources/view/+page.ts
@@ -3,8 +3,7 @@ import { users } from "$lib/api";
 import { error } from "@sveltejs/kit";
 
 export const load: PageLoad = async ({ url, parent }) => {
-
-  const resourceId = url.searchParams.get('id');
+  const resourceId = url.searchParams.get("id");
   if (resourceId) {
     error(404, {
       message: "Resource not found",

--- a/src/routes/app/spaces/+page.svelte
+++ b/src/routes/app/spaces/+page.svelte
@@ -23,7 +23,7 @@
 {#if $spacesList && $spacesList.length > 0}
   {#each $spacesList as space (space.id)}
     <a
-      href={`#/app/spaces/${space.id}`}
+      href={`/app/spaces/view?id=${space.id}`}
       class="flex border-black border event-row"
     >
       {#if space.images.length > 0}
@@ -57,7 +57,7 @@
   {/each}
 {:else}
   <p>no spaces yet, please create one.</p>
-  <a href="#/app/events/create" class="button inline-block">create space</a>
+  <a href="/app/events/create" class="button inline-block">create space</a>
 {/if}
 
 <Contribute />

--- a/src/routes/app/spaces/SpaceForm.svelte
+++ b/src/routes/app/spaces/SpaceForm.svelte
@@ -49,7 +49,7 @@
     try {
       const spaceId: Hash = await spaces.create(activeCalendarId, payload);
       toast.success("Space created!");
-      goto(`#/app/spaces/${spaceId}`);
+      goto(`/app/spaces/${spaceId}`);
     } catch (error) {
       console.error("Error creating space: ", error);
       toast.error("Error creating space!");
@@ -60,7 +60,7 @@
     try {
       await spaces.update(spaceId, payload);
       toast.success("Space updated!");
-      goto(`#/app/spaces/${spaceId}`);
+      goto(`/app/spaces/${spaceId}`);
     } catch (error) {
       console.error("Error updating space: ", error);
       toast.error("Error updating space!");

--- a/src/routes/app/spaces/edit/+page.svelte
+++ b/src/routes/app/spaces/edit/+page.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
-  import ResourceForm from "../../ResourceForm.svelte";
+  import SpaceForm from "../SpaceForm.svelte";
   import type { PageProps } from "./$types";
   import Delete from "$lib/components/dialog/Delete.svelte";
 
   let { data }: PageProps = $props();
 </script>
 
-<ResourceForm
+<SpaceForm
   data={data.form}
-  activeCalendarId={data.activeCalendarId!}
+  activeCalendarId={data.activeCalendarId}
   calendarDates={data.calendarDates}
 />
-{#if data.userRole === "admin"}
-  <Delete id={data.form.data.id!} name={data.form.data.name} type="resource" />
+{#if data.userRole == "admin"}
+  <Delete id={data.form.data.id!} name={data.form.data.name} type="space" />
 {/if}

--- a/src/routes/app/spaces/edit/+page.ts
+++ b/src/routes/app/spaces/edit/+page.ts
@@ -5,11 +5,16 @@ import { spaces, users, calendars } from "$lib/api";
 import { superValidate } from "sveltekit-superforms";
 import { zod } from "sveltekit-superforms/adapters";
 
-export const load: PageLoad = async ({ params, parent }) => {
-  const spaceId = params.id;
+export const load: PageLoad = async ({ url, parent }) => {
+
+  const spaceId = url.searchParams.get('id');
+  if (!spaceId) {
+    error(404, {
+      message: "Space not found",
+    });
+  }
 
   const space = await spaces.findById(spaceId);
-
   if (!space || !space.id) {
     error(404, {
       message: "Space not found",

--- a/src/routes/app/spaces/edit/+page.ts
+++ b/src/routes/app/spaces/edit/+page.ts
@@ -6,8 +6,7 @@ import { superValidate } from "sveltekit-superforms";
 import { zod } from "sveltekit-superforms/adapters";
 
 export const load: PageLoad = async ({ url, parent }) => {
-
-  const spaceId = url.searchParams.get('id');
+  const spaceId = url.searchParams.get("id");
   if (!spaceId) {
     error(404, {
       message: "Space not found",

--- a/src/routes/app/spaces/view/+page.svelte
+++ b/src/routes/app/spaces/view/+page.svelte
@@ -87,7 +87,7 @@
     <ImageGallery images={$space.images} />
 
     {#if data.userRole == "admin" || amOwner}
-      <a class="button" href="#/app/spaces/{$space!.id}/edit">Edit</a>
+      <a class="button" href="/app/spaces/edit?id={$space!.id}">Edit</a>
     {/if}
 
     <pre>{JSON.stringify($space, null, 2)}</pre>

--- a/src/routes/app/spaces/view/+page.ts
+++ b/src/routes/app/spaces/view/+page.ts
@@ -1,8 +1,15 @@
 import type { PageLoad } from "./$types";
 import { users } from "$lib/api";
+import { error } from "@sveltejs/kit";
 
-export const load: PageLoad = async ({ params, parent }) => {
-  const spaceId = params.id;
+export const load: PageLoad = async ({ url, parent }) => {
+
+  const spaceId = url.searchParams.get('id');
+  if (!spaceId) {
+    error(404, {
+      message: "Space not found",
+    });
+  }
 
   const parentData = await parent();
   const { activeCalendarId, publicKey } = parentData;

--- a/src/routes/app/spaces/view/+page.ts
+++ b/src/routes/app/spaces/view/+page.ts
@@ -3,8 +3,7 @@ import { users } from "$lib/api";
 import { error } from "@sveltejs/kit";
 
 export const load: PageLoad = async ({ url, parent }) => {
-
-  const spaceId = url.searchParams.get('id');
+  const spaceId = url.searchParams.get("id");
   if (!spaceId) {
     error(404, {
       message: "Space not found",

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -9,12 +9,6 @@ const config = {
   preprocess: vitePreprocess(),
   kit: {
     adapter: adapter(),
-    router: {
-      // Set router to type hash so we can build dynamic urls
-      // where we don't know the ID of an entity at build time.
-      // This means all urls in the app to start with a #
-      type: "hash",
-    },
   },
 };
 


### PR DESCRIPTION
This PR changes dynamic routes to use URL query params and removes hash routing due to issues building app for production when using hash routing.

Routes now have the following structure

- `/events`
- `/events/create`
- `/events/view?id=123`
- `/events/edit?id=123`
- `/spaces`
- `/spaces/create`
- `/spaces/view?id=123`
- `/spaces/edit?id=123`