### PR TITLE
Introduce last-write-win logic for calendar, event, resource and space updates

### DIFF
--- a/src/lib/api/calendars.ts
+++ b/src/lib/api/calendars.ts
@@ -206,7 +206,8 @@ async function onCalendarCreated(
           : undefined,
         spacePageText: spacePageText ? spacePageText : undefined,
         resourcePageText: resourcePageText ? resourcePageText : undefined,
-        lastWrite: meta.timestamp,
+        createdAt: meta.timestamp,
+        updatedAt: meta.timestamp,
       });
     } catch (e) {
       // Log error incase we try to insert the calendar twice.
@@ -224,7 +225,7 @@ async function onCalendarCreated(
         : undefined,
       spacePageText: spacePageText ? spacePageText : undefined,
       resourcePageText: resourcePageText ? resourcePageText : undefined,
-      lastWrite: meta.timestamp,
+      updatedAt: meta.timestamp,
     });
   }
 }
@@ -251,7 +252,7 @@ async function onCalendarUpdated(
   // equality, the hash is greater.
   if (
     !shouldUpdate(
-      calendar.lastWrite,
+      calendar.updatedAt,
       calendar.id,
       meta.timestamp,
       meta.operationId,
@@ -269,7 +270,7 @@ async function onCalendarUpdated(
       : undefined,
     spacePageText: spacePageText ? spacePageText : undefined,
     resourcePageText: resourcePageText ? resourcePageText : undefined,
-    lastWrite: meta.timestamp,
+    updatedAt: meta.timestamp,
   });
 }
 

--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -237,7 +237,8 @@ async function onEventCreated(
       id: meta.operationId,
       calendarId: meta.stream.id,
       ownerId: meta.author,
-      lastWrite: meta.timestamp,
+      createdAt: meta.timestamp,
+      updatedAt: meta.timestamp,
       ...data.fields,
     });
   } catch (e) {
@@ -264,7 +265,7 @@ function onEventUpdated(
     // Updates should only be applied if they have a greater timestamp or in the case of timestamp
     // equality, the hash is greater.
     if (
-      !shouldUpdate(event.lastWrite, event.id, meta.timestamp, meta.operationId)
+      !shouldUpdate(event.updatedAt, event.id, meta.timestamp, meta.operationId)
     ) {
       return;
     }
@@ -281,7 +282,7 @@ function onEventUpdated(
 
     await db.events.update(data.id, {
       ...data.fields,
-      lastWrite: meta.timestamp,
+      updatedAt: meta.timestamp,
     });
   });
 }

--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -255,7 +255,7 @@ function onEventUpdated(
   const eventTimeSpan = new TimeSpanClass({ start: startDate, end: endDate });
 
   return db.transaction("rw", db.events, db.bookingRequests, async () => {
-    const event = await events.findById(data.id);
+    const event = await db.events.get(data.id);
     if (!event) {
       // The event may have been deleted.
       return;

--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -1,4 +1,5 @@
 import { db } from "$lib/db";
+import { shouldUpdate } from "$lib/lww";
 import { promiseResult } from "$lib/promiseMap";
 import { TimeSpanClass } from "$lib/timeSpan";
 import { auth, events, publish } from ".";
@@ -221,7 +222,7 @@ export async function process(message: ApplicationMessage) {
     case "event_created":
       return await onEventCreated(meta, data);
     case "event_updated":
-      return await onEventUpdated(data);
+      return await onEventUpdated(meta, data);
     case "event_deleted":
       return await onEventDeleted(data);
   }
@@ -236,19 +237,38 @@ async function onEventCreated(
       id: meta.operationId,
       calendarId: meta.stream.id,
       ownerId: meta.author,
+      lastWrite: meta.timestamp,
       ...data.fields,
     });
   } catch (e) {
+    // In case we try to add the event twice log the error.
     console.error(e);
   }
 }
 
-function onEventUpdated(data: EventUpdated["data"]): Promise<void> {
+function onEventUpdated(
+  meta: StreamMessageMeta,
+  data: EventUpdated["data"],
+): Promise<void> {
   const eventId = data.id;
   const { endDate, startDate } = data.fields;
   const eventTimeSpan = new TimeSpanClass({ start: startDate, end: endDate });
 
   return db.transaction("rw", db.events, db.bookingRequests, async () => {
+    const event = await events.findById(data.id);
+    if (!event) {
+      // The event may have been deleted.
+      return;
+    }
+
+    // Updates should only be applied if they have a greater timestamp or in the case of timestamp
+    // equality, the hash is greater.
+    if (
+      !shouldUpdate(event.lastWrite, event.id, meta.timestamp, meta.operationId)
+    ) {
+      return;
+    }
+
     // Update `validTime` field of all booking requests associated with this event.
     await db.bookingRequests.where({ eventId }).modify((request) => {
       const requestTimeSpan = new TimeSpanClass(request.timeSpan);
@@ -261,6 +281,7 @@ function onEventUpdated(data: EventUpdated["data"]): Promise<void> {
 
     await db.events.update(data.id, {
       ...data.fields,
+      lastWrite: meta.timestamp,
     });
   });
 }

--- a/src/lib/api/resources.ts
+++ b/src/lib/api/resources.ts
@@ -227,7 +227,7 @@ function onResourceUpdated(
   const resourceAvailability = data.fields.availability;
 
   return db.transaction("rw", db.resources, db.bookingRequests, async () => {
-    const resource = await resources.findById(data.id);
+    const resource = await db.resources.get(data.id);
     if (!resource) {
       // The resource may have been deleted.
       return;

--- a/src/lib/api/resources.ts
+++ b/src/lib/api/resources.ts
@@ -211,7 +211,8 @@ async function onResourceCreated(
       id: meta.operationId,
       calendarId: meta.stream.id,
       ownerId: meta.author,
-      lastWrite: meta.timestamp,
+      createdAt: meta.timestamp,
+      updatedAt: meta.timestamp,
       ...data.fields,
     });
   } catch (e) {
@@ -237,7 +238,7 @@ function onResourceUpdated(
     // equality, the hash is greater.
     if (
       !shouldUpdate(
-        resource.lastWrite,
+        resource.updatedAt,
         resource.id,
         meta.timestamp,
         meta.operationId,
@@ -271,7 +272,7 @@ function onResourceUpdated(
     // @TODO: add related location to spaces object.
     await db.resources.update(data.id, {
       ...data.fields,
-      lastWrite: meta.timestamp,
+      updatedAt: meta.timestamp,
     });
   });
 }

--- a/src/lib/api/spaces.ts
+++ b/src/lib/api/spaces.ts
@@ -228,7 +228,7 @@ function onSpaceUpdated(
   const spaceAvailability = data.fields.availability;
 
   return db.transaction("rw", db.spaces, db.bookingRequests, async () => {
-    const space = await spaces.findById(data.id);
+    const space = await db.spaces.get(data.id);
     if (!space) {
       // The space may have been deleted.
       return;

--- a/src/lib/api/spaces.ts
+++ b/src/lib/api/spaces.ts
@@ -212,7 +212,8 @@ async function onSpaceCreated(
       id: meta.operationId,
       calendarId: meta.stream.id,
       ownerId: meta.author,
-      lastWrite: meta.timestamp,
+      createdAt: meta.timestamp,
+      updatedAt: meta.timestamp,
       ...data.fields,
     });
   } catch (e) {
@@ -237,7 +238,7 @@ function onSpaceUpdated(
     // Updates should only be applied if they have a greater timestamp or in the case of timestamp
     // equality, the hash is greater.
     if (
-      !shouldUpdate(space.lastWrite, space.id, meta.timestamp, meta.operationId)
+      !shouldUpdate(space.updatedAt, space.id, meta.timestamp, meta.operationId)
     ) {
       return;
     }
@@ -270,7 +271,7 @@ function onSpaceUpdated(
     // @TODO: add related location to spaces object.
     await db.spaces.update(data.id, {
       ...data.fields,
-      lastWrite: meta.timestamp,
+      updatedAt: meta.timestamp,
     });
   });
 }

--- a/src/lib/lww.ts
+++ b/src/lib/lww.ts
@@ -11,6 +11,6 @@ export function shouldUpdate(
   if (currentId < updateId) {
     return true;
   } else {
-    throw Error("LWW comparator requires that ids are universally unique")
+    throw Error("LWW comparator requires that ids are universally unique");
   }
 }

--- a/src/lib/lww.ts
+++ b/src/lib/lww.ts
@@ -1,0 +1,16 @@
+export function shouldUpdate(
+  currentTimestamp: bigint,
+  currentId: Hash,
+  updateTimestamp: bigint,
+  updateId: Hash,
+): boolean {
+  if (currentTimestamp < updateTimestamp) {
+    return true;
+  }
+
+  if (currentId < updateId) {
+    return true;
+  } else {
+    throw Error("LWW comparator requires that ids are universally unique")
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -659,7 +659,8 @@ type Calendar = {
   calendarInstructions?: string;
   spacePageText?: string;
   resourcePageText?: string;
-  lastWrite: bigint;
+  createdAt: bigint;
+  updatedAt: bigint;
 };
 
 type AccessRequest = {
@@ -682,21 +683,24 @@ type CalendarEvent = {
   id: Hash;
   calendarId: Hash;
   ownerId: PublicKey;
-  lastWrite: bigint;
+  createdAt: bigint;
+  updatedAt: bigint;
 } & EventFields;
 
 type Space = {
   id: Hash;
   calendarId: Hash;
   ownerId: PublicKey;
-  lastWrite: bigint;
+  createdAt: bigint;
+  updatedAt: bigint;
 } & SpaceFields;
 
 type Resource = {
   id: Hash;
   calendarId: Hash;
   ownerId: PublicKey;
-  lastWrite: bigint;
+  createdAt: bigint;
+  updatedAt: bigint;
 } & ResourceFields;
 
 type BookingRequestStatus = "accepted" | "rejected" | "pending";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -682,18 +682,21 @@ type CalendarEvent = {
   id: Hash;
   calendarId: Hash;
   ownerId: PublicKey;
+  lastWrite: bigint;
 } & EventFields;
 
 type Space = {
   id: Hash;
   calendarId: Hash;
   ownerId: PublicKey;
+  lastWrite: bigint;
 } & SpaceFields;
 
 type Resource = {
   id: Hash;
   calendarId: Hash;
   ownerId: PublicKey;
+  lastWrite: bigint;
 } & ResourceFields;
 
 type BookingRequestStatus = "accepted" | "rejected" | "pending";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -659,6 +659,7 @@ type Calendar = {
   calendarInstructions?: string;
   spacePageText?: string;
   resourcePageText?: string;
+  lastWrite: bigint;
 };
 
 type AccessRequest = {

--- a/src/lib/utils/faker.ts
+++ b/src/lib/utils/faker.ts
@@ -25,13 +25,21 @@ export function createCalendarMessage(
   auth: PublicKey,
   headerData: { type: "calendar_created" },
   fieldsOverwrites?: Partial<CalendarFields>,
-): ApplicationMessage & { data: { type: "calendar_created" } };
+): ApplicationMessage & {
+  data: { type: "calendar_created" };
+};
 export function createCalendarMessage(
   id: Hash,
   auth: PublicKey,
-  headerData: { type: "calendar_updated"; calendarId: string },
+  headerData: {
+    type: "calendar_updated";
+    calendarId: string;
+    timestamp: number;
+  },
   fieldsOverwrites?: Partial<CalendarFields>,
-): ApplicationMessage & { data: { type: "calendar_updated" } };
+): ApplicationMessage & {
+  data: { type: "calendar_updated" };
+};
 export function createCalendarMessage(
   id: Hash,
   auth: PublicKey,
@@ -43,14 +51,16 @@ export function createCalendarMessage(
   id: Hash,
   author: PublicKey,
   headerData:
-    | { type: "calendar_created" }
+    | { type: "calendar_created"; timestamp?: number }
     | {
         type: "calendar_updated";
         calendarId: string;
+        timestamp: number;
       }
     | {
         type: "calendar_deleted";
         calendarId: string;
+        timestamp?: number;
       },
   fieldsOverwrites?: Partial<CalendarFields>,
 ): ApplicationMessage {
@@ -84,6 +94,9 @@ export function createCalendarMessage(
       author: author,
       stream: STREAM,
       logPath: LOG_PATH,
+      timestamp: headerData.timestamp
+        ? BigInt(headerData.timestamp)
+        : BigInt(0),
     },
     event: "application",
     data,
@@ -93,19 +106,19 @@ export function createCalendarMessage(
 export function createEventMessage(
   id: Hash,
   auth: PublicKey,
-  headerData: { type: "event_created" },
+  headerData: { type: "event_created"; timestamp?: number },
   fieldsOverwrites?: Partial<EventFields>,
 ): ApplicationMessage & { data: { type: "event_created" } };
 export function createEventMessage(
   id: Hash,
   auth: PublicKey,
-  headerData: { type: "event_updated"; eventId: string },
+  headerData: { type: "event_updated"; eventId: string; timestamp: number },
   fieldsOverwrites?: Partial<EventFields>,
 ): ApplicationMessage & { data: { type: "event_updated" } };
 export function createEventMessage(
   id: Hash,
   auth: PublicKey,
-  headerData: { type: "event_deleted"; eventId: string },
+  headerData: { type: "event_deleted"; eventId: string; timestamp?: number },
   fieldsOverwrites?: Partial<EventFields>,
 ): ApplicationMessage & { data: { type: "event_deleted" } };
 
@@ -113,9 +126,9 @@ export function createEventMessage(
   id: Hash,
   author: PublicKey,
   headerData:
-    | { type: "event_created" }
-    | { type: "event_updated"; eventId: string }
-    | { type: "event_deleted"; eventId: string },
+    | { type: "event_created"; timestamp?: number }
+    | { type: "event_updated"; eventId: string; timestamp: number }
+    | { type: "event_deleted"; eventId: string; timestamp?: number },
   fieldsOverwrites?: Partial<EventFields>,
 ): ApplicationMessage {
   const eventFields = createEventFields(fieldsOverwrites);
@@ -148,6 +161,9 @@ export function createEventMessage(
       author,
       stream: STREAM,
       logPath: LOG_PATH,
+      timestamp: headerData.timestamp
+        ? BigInt(headerData.timestamp)
+        : BigInt(0),
     },
     event: "application",
     data,
@@ -157,19 +173,27 @@ export function createEventMessage(
 export function createResourceMessage(
   id: Hash,
   auth: PublicKey,
-  headerData: { type: "resource_created" },
+  headerData: { type: "resource_created"; timestamp?: number },
   fieldsOverwrites?: Partial<ResourceFields>,
 ): ApplicationMessage & { data: { type: "resource_created" } };
 export function createResourceMessage(
   id: Hash,
   auth: PublicKey,
-  headerData: { type: "resource_updated"; resourceId: string },
+  headerData: {
+    type: "resource_updated";
+    resourceId: string;
+    timestamp: number;
+  },
   fieldsOverwrites?: Partial<ResourceFields>,
 ): ApplicationMessage & { data: { type: "resource_updated" } };
 export function createResourceMessage(
   id: Hash,
   auth: PublicKey,
-  headerData: { type: "resource_deleted"; resourceId: string },
+  headerData: {
+    type: "resource_deleted";
+    resourceId: string;
+    timestamp?: number;
+  },
   fieldsOverwrites?: Partial<ResourceFields>,
 ): ApplicationMessage & { data: { type: "resource_deleted" } };
 
@@ -177,9 +201,9 @@ export function createResourceMessage(
   id: Hash,
   author: PublicKey,
   headerData:
-    | { type: "resource_created" }
-    | { type: "resource_updated"; resourceId: string }
-    | { type: "resource_deleted"; resourceId: string },
+    | { type: "resource_created"; timestamp?: number }
+    | { type: "resource_updated"; resourceId: string; timestamp: number }
+    | { type: "resource_deleted"; resourceId: string; timestamp?: number },
   fieldsOverwrites?: Partial<ResourceFields>,
 ): ApplicationMessage {
   const resourceFields = createResourceFields(fieldsOverwrites);
@@ -212,6 +236,9 @@ export function createResourceMessage(
       author,
       stream: STREAM,
       logPath: LOG_PATH,
+      timestamp: headerData.timestamp
+        ? BigInt(headerData.timestamp)
+        : BigInt(0),
     },
     event: "application",
     data,
@@ -223,17 +250,17 @@ export function createSpaceMessage(
   auth: PublicKey,
   headerData: { type: "space_created" },
   fieldsOverwrites?: Partial<SpaceFields>,
-): ApplicationMessage & { data: { type: "space_created" } };
+): ApplicationMessage & { data: { type: "space_created"; timestamp?: number } };
 export function createSpaceMessage(
   id: Hash,
   auth: PublicKey,
-  headerData: { type: "space_updated"; spaceId: string },
+  headerData: { type: "space_updated"; spaceId: string; timestamp: number },
   fieldsOverwrites?: Partial<SpaceFields>,
 ): ApplicationMessage & { data: { type: "space_updated" } };
 export function createSpaceMessage(
   id: Hash,
   auth: PublicKey,
-  headerData: { type: "space_deleted"; spaceId: string },
+  headerData: { type: "space_deleted"; spaceId: string; timestamp?: number },
   fieldsOverwrites?: Partial<SpaceFields>,
 ): ApplicationMessage & { data: { type: "space_deleted" } };
 
@@ -241,9 +268,9 @@ export function createSpaceMessage(
   id: Hash,
   author: PublicKey,
   headerData:
-    | { type: "space_created" }
-    | { type: "space_updated"; spaceId: string }
-    | { type: "space_deleted"; spaceId: string },
+    | { type: "space_created"; timestamp?: number }
+    | { type: "space_updated"; spaceId: string; timestamp: number }
+    | { type: "space_deleted"; spaceId: string; timestamp?: number },
   fieldsOverwrites?: Partial<SpaceFields>,
 ): ApplicationMessage {
   const spaceFields = createSpaceFields(fieldsOverwrites);
@@ -276,6 +303,9 @@ export function createSpaceMessage(
       author,
       stream: STREAM,
       logPath: LOG_PATH,
+      timestamp: headerData.timestamp
+        ? BigInt(headerData.timestamp)
+        : BigInt(0),
     },
     event: "application",
     data,
@@ -302,6 +332,7 @@ export function createBookingRequestMessage(
       author,
       stream: STREAM,
       logPath: LOG_PATH,
+      timestamp: BigInt(0),
     },
     event: "application",
     data: {
@@ -329,6 +360,7 @@ export function createBookingResponseMessage(
       author,
       stream: STREAM,
       logPath: LOG_PATH,
+      timestamp: BigInt(0),
     },
     event: "application",
     data: {
@@ -355,6 +387,7 @@ export function createAssignRoleMessage(
       author,
       stream: STREAM,
       logPath: LOG_PATH,
+      timestamp: BigInt(0),
     },
     event: "application",
     data: {
@@ -377,6 +410,7 @@ export function createRequestAccessMessage(
       author,
       stream: STREAM,
       logPath: LOG_PATH,
+      timestamp: BigInt(0),
     },
     event: "application",
     data: {
@@ -408,6 +442,7 @@ export function createAccessResponseMessage(
       author,
       stream: STREAM,
       logPath: LOG_PATH,
+      timestamp: BigInt(0),
     },
     event: "application",
     data: {

--- a/tests/api/access.test.ts
+++ b/tests/api/access.test.ts
@@ -38,6 +38,7 @@ describe("access tests", () => {
         author: requestingAuthor,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {
@@ -61,6 +62,7 @@ describe("access tests", () => {
         author: OWNER_PUBLIC_KEY,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {
@@ -82,6 +84,7 @@ describe("access tests", () => {
         author: OWNER_PUBLIC_KEY,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {

--- a/tests/api/auth.test.ts
+++ b/tests/api/auth.test.ts
@@ -40,6 +40,7 @@ describe("owners can perform updates", () => {
         author: OWNER_PUBLIC_KEY,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {
@@ -61,6 +62,7 @@ describe("owners can perform updates", () => {
         author: OWNER_PUBLIC_KEY,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {
@@ -82,6 +84,7 @@ describe("owners can perform updates", () => {
         author: OWNER_PUBLIC_KEY,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {
@@ -103,6 +106,7 @@ describe("owners can perform updates", () => {
         author: OWNER_PUBLIC_KEY,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {
@@ -126,6 +130,7 @@ describe("non-owners cannot perform updates", () => {
         author: NON_OWNER_PUBLIC_KEY,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {
@@ -133,6 +138,7 @@ describe("non-owners cannot perform updates", () => {
         data: {
           id: CALENDAR_ID,
           fields: {
+            userName: "Me",
             name: "New calendar name",
             dates: [
               {
@@ -160,6 +166,7 @@ describe("non-owners cannot perform updates", () => {
         author: NON_OWNER_PUBLIC_KEY,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {
@@ -183,6 +190,7 @@ describe("non-owners cannot perform updates", () => {
         author: NON_OWNER_PUBLIC_KEY,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {
@@ -206,6 +214,7 @@ describe("non-owners cannot perform updates", () => {
         author: NON_OWNER_PUBLIC_KEY,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {
@@ -231,6 +240,7 @@ describe("admin can update things too", () => {
         author: OWNER_PUBLIC_KEY,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {
@@ -253,6 +263,7 @@ describe("admin can update things too", () => {
         author: NON_OWNER_PUBLIC_KEY,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {
@@ -278,6 +289,7 @@ describe("admin can update things too", () => {
         author: NON_OWNER_PUBLIC_KEY,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {
@@ -303,6 +315,7 @@ describe("admin can update things too", () => {
         author: NON_OWNER_PUBLIC_KEY,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {
@@ -328,6 +341,7 @@ describe("admin can update things too", () => {
         author: NON_OWNER_PUBLIC_KEY,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {

--- a/tests/api/booking.test.ts
+++ b/tests/api/booking.test.ts
@@ -55,6 +55,7 @@ test("booking queries", async () => {
       author: OWNER_PUBLIC_KEY,
       stream: STREAM,
       logPath: LOG_PATH,
+      timestamp: BigInt(0),
     },
     event: "application",
     data: {
@@ -87,6 +88,7 @@ test("booking queries", async () => {
       author: OWNER_PUBLIC_KEY,
       stream: STREAM,
       logPath: LOG_PATH,
+      timestamp: BigInt(0),
     },
     event: "application",
     data: {

--- a/tests/api/bookingTimespan.test.ts
+++ b/tests/api/bookingTimespan.test.ts
@@ -40,6 +40,7 @@ describe("maintain booking request timespan validity", () => {
         author: OWNER_PUBLIC_KEY,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {
@@ -77,6 +78,7 @@ describe("maintain booking request timespan validity", () => {
         author: OWNER_PUBLIC_KEY,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {
@@ -112,6 +114,7 @@ describe("maintain booking request timespan validity", () => {
         author: OWNER_PUBLIC_KEY,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {
@@ -142,6 +145,7 @@ describe("maintain booking request timespan validity", () => {
         author: OWNER_PUBLIC_KEY,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {
@@ -177,6 +181,7 @@ describe("maintain booking request timespan validity", () => {
         author: OWNER_PUBLIC_KEY,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {
@@ -214,6 +219,7 @@ describe("maintain booking request timespan validity", () => {
         author: OWNER_PUBLIC_KEY,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {
@@ -249,6 +255,7 @@ describe("maintain booking request timespan validity", () => {
         author: OWNER_PUBLIC_KEY,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {
@@ -279,6 +286,7 @@ describe("maintain booking request timespan validity", () => {
         author: OWNER_PUBLIC_KEY,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {

--- a/tests/api/dependencies.test.ts
+++ b/tests/api/dependencies.test.ts
@@ -34,6 +34,7 @@ describe("dependencies tests", () => {
         author: OWNER_PUBLIC_KEY,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {
@@ -56,6 +57,7 @@ describe("dependencies tests", () => {
         author: OWNER_PUBLIC_KEY,
         stream: STREAM,
         logPath: LOG_PATH,
+        timestamp: BigInt(0),
       },
       event: "application",
       data: {

--- a/tests/api/outOfOrder.test.ts
+++ b/tests/api/outOfOrder.test.ts
@@ -36,6 +36,7 @@ const updateCalendar = createCalendarMessage(
   {
     type: "calendar_updated",
     calendarId: CALENDAR_ID,
+    timestamp: 10,
   },
 );
 const createEventOO1 = createEventMessage("event_001", OWNER_PUBLIC_KEY, {
@@ -47,6 +48,7 @@ const updateEvent001 = createEventMessage(
   {
     type: "event_updated",
     eventId: "event_001",
+    timestamp: 10,
   },
 );
 const createEventOO2 = createEventMessage("event_002", OWNER_PUBLIC_KEY, {
@@ -73,6 +75,7 @@ const updateResource001 = createResourceMessage(
   {
     type: "resource_updated",
     resourceId: "resource_001",
+    timestamp: 10,
   },
 );
 const createResourceOO2 = createResourceMessage(
@@ -99,6 +102,7 @@ const updateSpace001 = createSpaceMessage(
   {
     type: "space_updated",
     spaceId: "space_001",
+    timestamp: 10,
   },
 );
 const createSpaceOO2 = createSpaceMessage("space_002", OWNER_PUBLIC_KEY, {
@@ -164,6 +168,7 @@ const updateSpace002 = createSpaceMessage(
   {
     type: "space_updated",
     spaceId: "space_003",
+    timestamp: 10,
   },
 );
 const updateResource002 = createResourceMessage(
@@ -172,6 +177,7 @@ const updateResource002 = createResourceMessage(
   {
     type: "resource_updated",
     resourceId: "resource_003",
+    timestamp: 10,
   },
 );
 


### PR DESCRIPTION
Introduce `createdAt` and `updatedAt` fields to calendar, space, resource and event. Compare the `timestamp` of any arriving update messages to local `updatedAt` field, and only process updates where the timestamp is greater. In the case of the two timestamps being equal, we use the operation hashes as tie-breaker. 