### PR TITLE
Use conditional compilation to ensure keystore support for Windows

### DIFF
--- a/src-tauri/src/keystore.rs
+++ b/src-tauri/src/keystore.rs
@@ -1,8 +1,10 @@
 //! Persistent storage for private keys.
 
+#[cfg(not(windows))]
+use std::os::unix::fs::PermissionsExt;
+
 use std::fs::{self, File};
 use std::io::prelude::*;
-use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
 use anyhow::{Context, Result};
@@ -35,7 +37,12 @@ impl KeyStore for PrivateKey {
         file.sync_all()?;
 
         let mut permissions = file.metadata()?.permissions();
+
+        #[cfg(windows)]
+        permissions.set_readonly(true);
+        #[cfg(not(windows))]
         permissions.set_mode(0o600);
+
         fs::set_permissions(path, permissions)?;
 
         Ok(())


### PR DESCRIPTION
I introduce a bug with the keystore: it required a Unix-specific trait and associated functionality, which ultimately resulted in a panic on Windows.

We now match on the target OS and only import the trait if we're not running on Windows. We also set the keystore file permissions based on the target OS: either `read-only` for Windows or else `0o600`.