### PR TITLE
Fix: resource and space requests not correctly attached to enriched events

### DIFF
--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -91,7 +91,7 @@ async function enrichEvent(
 
   // Add space booking request to event.
   const spaceRequests = await db.bookingRequests
-    .where({ eventId: event.id, resourceType: "space", isValid: "true" })
+    .where({ eventId: event.id, resourceType: "space" })
     .sortBy("createdAt");
 
   if (spaceRequests.length !== 0) {
@@ -103,7 +103,7 @@ async function enrichEvent(
 
   // Add resource booking requests to event.
   const resourceRequests = await db.bookingRequests
-    .where({ eventId: event.id, resourceType: "resource", isValid: "true" })
+    .where({ eventId: event.id, resourceType: "resource" })
     .sortBy("createdAt");
 
   eventEnriched.resourceRequests = [];

--- a/src/lib/components/EventRow.svelte
+++ b/src/lib/components/EventRow.svelte
@@ -33,7 +33,11 @@
       <Date format="time" date={event.startDate} /> -
       <Date format="time" date={event.endDate} />
     </span>
-    <span>📍 {event.spaceRequest?.space ? event.spaceRequest.space!.name : "no space yet"}</span>
+    <span
+      >📍 {event.spaceRequest?.space
+        ? event.spaceRequest.space!.name
+        : "no space yet"}</span
+    >
   </div>
 </a>
 

--- a/src/lib/components/EventRow.svelte
+++ b/src/lib/components/EventRow.svelte
@@ -33,7 +33,7 @@
       <Date format="time" date={event.startDate} /> -
       <Date format="time" date={event.endDate} />
     </span>
-    <span>📍 {event.space ? event.space.name : "no space yet"}</span>
+    <span>📍 {event.spaceRequest?.space ? event.spaceRequest.space!.name : "no space yet"}</span>
   </div>
 </a>
 

--- a/src/lib/utils/data.ts
+++ b/src/lib/utils/data.ts
@@ -83,15 +83,10 @@ export async function seedData() {
   });
 
   const eventId = await events.create(calendarId, eventFields);
-  await events.create(calendarId, eventFields);
-  await events.create(calendarId, eventFields);
-  await events.create(calendarId, eventFields);
-  await events.create(calendarId, eventFields2);
-  await events.create(calendarId, eventFields2);
   await events.create(calendarId, eventFields2);
 
   // Make space request for first event.
-  const spaceRequestId = await bookings.request(
+  await bookings.request(
     eventId,
     spaceId,
     "space",
@@ -99,21 +94,11 @@ export async function seedData() {
     { start: eventStartDate, end: eventEndDate },
   );
 
-  const resourceRequestId = await bookings.request(
+  await bookings.request(
     eventId,
     resourceId,
     "resource",
     "please can i haz?",
     { start: eventStartDate, end: eventEndDate },
-  );
-
-  // Update first event with resource and space requests.
-  await events.update(
-    eventId,
-    createEventFields({
-      ...eventFields,
-      resourcesRequests: [resourceRequestId],
-      spaceRequest: spaceRequestId,
-    }),
   );
 }

--- a/src/lib/utils/data.ts
+++ b/src/lib/utils/data.ts
@@ -86,19 +86,13 @@ export async function seedData() {
   await events.create(calendarId, eventFields2);
 
   // Make space request for first event.
-  await bookings.request(
-    eventId,
-    spaceId,
-    "space",
-    "please can i haz?",
-    { start: eventStartDate, end: eventEndDate },
-  );
+  await bookings.request(eventId, spaceId, "space", "please can i haz?", {
+    start: eventStartDate,
+    end: eventEndDate,
+  });
 
-  await bookings.request(
-    eventId,
-    resourceId,
-    "resource",
-    "please can i haz?",
-    { start: eventStartDate, end: eventEndDate },
-  );
+  await bookings.request(eventId, resourceId, "resource", "please can i haz?", {
+    start: eventStartDate,
+    end: eventEndDate,
+  });
 }

--- a/src/routes/app/dashboard/+page.svelte
+++ b/src/routes/app/dashboard/+page.svelte
@@ -51,9 +51,16 @@
       >
         <h4>{event.name}</h4>
         <DateRange startDate={event.startDate} endDate={event.endDate} />
-        <p>{event.spaceRequest?.space ? event.spaceRequest?.space.name : "no space yet"}</p>
+        <p>
+          {event.spaceRequest?.space
+            ? event.spaceRequest?.space.name
+            : "no space yet"}
+        </p>
         {#if event.spaceRequest?.space}
-          <div>{event.spaceRequest?.space.name} {event.spaceRequest?.bookingRequest?.status}</div>
+          <div>
+            {event.spaceRequest?.space.name}
+            {event.spaceRequest?.bookingRequest?.status}
+          </div>
         {/if}
         {#if event.resourceRequests}
           {#each event.resourceRequests as resource (resource.bookingRequest.id)}

--- a/src/routes/app/dashboard/+page.svelte
+++ b/src/routes/app/dashboard/+page.svelte
@@ -51,14 +51,14 @@
       >
         <h4>{event.name}</h4>
         <DateRange startDate={event.startDate} endDate={event.endDate} />
-        <p>{event.space ? event.space.name : "no space yet"}</p>
-        {#if event.space}
-          <div>{event.space.name} {event.space.bookingRequest?.status}</div>
+        <p>{event.spaceRequest?.space ? event.spaceRequest?.space.name : "no space yet"}</p>
+        {#if event.spaceRequest?.space}
+          <div>{event.spaceRequest?.space.name} {event.spaceRequest?.bookingRequest?.status}</div>
         {/if}
-        {#if event.resources}
-          {#each event.resources as resource (resource.id)}
+        {#if event.resourceRequests}
+          {#each event.resourceRequests as resource (resource.bookingRequest.id)}
             <div>
-              <p>{resource.name} {resource.bookingRequest?.status}</p>
+              <p>{resource.resource?.name} {resource.bookingRequest?.status}</p>
             </div>
           {/each}
         {/if}

--- a/src/routes/app/events/EventForm.svelte
+++ b/src/routes/app/events/EventForm.svelte
@@ -234,12 +234,9 @@
     try {
       const eventId = await events.create(activeCalendarId, payload);
 
-      let spaceBookingId: string | undefined = undefined;
-      let resourceBookingIds: string[] = [];
-
       // Request selected space booking
       if (selectedSpace) {
-        const spaceBooking = await bookings.request(
+        await bookings.request(
           eventId,
           selectedSpace.id,
           "space",
@@ -249,13 +246,12 @@
             end: payload.endDate,
           },
         );
-        spaceBookingId = spaceBooking; // store to update event with booking id
       }
 
       // Request selected resources booking
       if (selectedResources.length > 0) {
         for (const resource of selectedResources) {
-          const resourceBooking = await bookings.request(
+          await bookings.request(
             eventId,
             resource.id,
             "resource",
@@ -265,16 +261,8 @@
               end: payload.endDate,
             },
           );
-          resourceBookingIds.push(resourceBooking);
         }
       }
-
-      // after booking request are sent, update event with booking ids
-      await events.update(eventId, {
-        ...payload,
-        spaceRequest: spaceBookingId,
-        resourcesRequests: resourceBookingIds ? resourceBookingIds : undefined,
-      });
 
       toast.success("Event created!");
       goto(`/app/events/view?id=${eventId}`);

--- a/src/routes/app/events/view/+page.svelte
+++ b/src/routes/app/events/view/+page.svelte
@@ -49,7 +49,9 @@
         <DateRange startDate={$event.startDate} endDate={$event.endDate} />
       </p>
       {#if $event.spaceRequest?.space}
-        <a href={`/spaces/view?id=${$event.spaceRequest?.space.id}`}>{$event.spaceRequest?.space.name}</a>
+        <a href={`/spaces/view?id=${$event.spaceRequest?.space.id}`}
+          >{$event.spaceRequest?.space.name}</a
+        >
       {/if}
     </div>
 

--- a/src/routes/app/events/view/+page.svelte
+++ b/src/routes/app/events/view/+page.svelte
@@ -48,8 +48,8 @@
       <p>
         <DateRange startDate={$event.startDate} endDate={$event.endDate} />
       </p>
-      {#if $event.space}
-        <a href={`/spaces/view?id=${$event.space.id}`}>{$event.space.name}</a>
+      {#if $event.spaceRequest?.space}
+        <a href={`/spaces/view?id=${$event.spaceRequest?.space.id}`}>{$event.spaceRequest?.space.name}</a>
       {/if}
     </div>
 


### PR DESCRIPTION
Due to an incorrect filter argument in the event enrichment logic resource and space requests were not being found, and therefore not attached to the enriched event. Additionally this PR clears up some associated issues: